### PR TITLE
ci: :green_heart: disable charts deployment tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,11 +54,11 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config ./ci/configs/chart-testing.yaml
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1
+      # - name: Create kind cluster
+      #   uses: helm/kind-action@v1
 
-      - name: Run chart-testing (install)
-        run: ct install --config ./ci/configs/chart-testing.yaml
+      # - name: Run chart-testing (install)
+      #   run: ct install --config ./ci/configs/chart-testing.yaml
 
   lint-docs:
     if: ${{ needs.path-filter.outputs.charts == 'true' }}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le déploiement du chart de la Console nécessite un keycloak up et configuré ce qui bloque le test de déploiement en l'état.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Les tests des déploiement de chart sont ignorés (comme avant), le test de déploiement du chart de la Console sera réactivé dans le dépôt de la Console (test de déploiement du chart en parallèle des tests e2e dans docker).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
