### PR TITLE
feat: :sparkles: handle cnpg restore mode in console chart

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 1.5.2
+version: 1.6.0
 appVersion: 8.8.2
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.2](https://img.shields.io/badge/AppVersion-8.8.2-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.2](https://img.shields.io/badge/AppVersion-8.8.2-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 
@@ -90,23 +90,24 @@ A Helm chart to deploy Cloud Pi Native Console
 | cnpg.backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
 | cnpg.backup.retentionPolicy | string | `"30d"` | Retention policy for cnpg backups recurrences. |
 | cnpg.backup.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for cnpg backups. |
-| cnpg.backup.s3Credentials.accessKeyId.value | string | `""` | S3 accessKeyId value used for cnpg backups. |
+| cnpg.backup.s3Credentials.accessKeyId.value | string | `""` | S3 accessKeyId value used for cnpg backups. Only needed if `backup.s3Credentials.create` is set to `true`. |
 | cnpg.backup.s3Credentials.create | bool | `false` | Whether or not to create kuebernetes secret used for cnpg backups. It will use `name`, `accessKeyId.key`, `accessKeyId.value`, `secretAccessKey.key` and `secretAccessKey.value` to create the secret. |
-| cnpg.backup.s3Credentials.name | string | `""` | S3 kuebernetes secret name used for cnpg backups. |
 | cnpg.backup.s3Credentials.secretAccessKey.key | string | `"secretAccessKey"` | S3 secretAccessKey kubernetes secret key used for cnpg backups. |
-| cnpg.backup.s3Credentials.secretAccessKey.value | string | `""` | S3 secretAccessKey value used for cnpg backups. |
+| cnpg.backup.s3Credentials.secretAccessKey.value | string | `""` | S3 secretAccessKey value used for cnpg backups. Only needed if `backup.s3Credentials.create` is set to `true`. |
+| cnpg.backup.s3Credentials.secretName | string | `""` | S3 kuebernetes secret name used for cnpg backups. |
 | cnpg.dbName | string | `"dso-console-db"` | Name of the database. |
 | cnpg.enableSuperuserAccess | bool | `true` | Enable superuser access. |
 | cnpg.enabled | bool | `false` | Whether or not cnpg cluster deployment should be enabled. |
 | cnpg.exposed | bool | `false` | Whether or not a NodePort service should be created to exposed the database. |
+| cnpg.imageName | string | `""` | Name of the image used for database. By default (empty string), the operator will install the latest available minor version of the latest major version of PostgreSQL when the operator was released |
 | cnpg.instances | int | `3` | Number of instances to spawn in the cluster. |
-| cnpg.mode | string | `"primary"` | Mode used to deploy the cnpg cluster, it should be `primary` or `replica`. |
-| cnpg.nameOverride | string | `""` | Provide a name in place of the default cnpg cluster name. |
+| cnpg.mode | string | `"primary"` | Mode used to deploy the cnpg cluster, it should be `primary`, `replica` or `restore`. |
+| cnpg.nameOverride | string | `""` | Provide a name in place of the default cnpg cluster name. The cnpg operator adds the cluster name to S3's `destinationPath`, so it is necessary to provide the exact match of the main cluster when using `replica` or `restore` mode. |
 | cnpg.nodePort | string | `nil` | Port used for NodePort service. Needs `exposed` tu be true. |
 | cnpg.primaryUpdateStrategy | string | `"unsupervised"` | Rolling update strategy used : unsupervised: automated update of the primary once all replicas have been upgraded (default) supervised: requires manual supervision to perform the switchover of the primary |
 | cnpg.pvcSize | string | `"10Gi"` | Size of the PVC used by each cnpg instance. |
-| cnpg.replica.host | string | `nil` | Primary cnpg cluster host used for replica mode. |
-| cnpg.replica.port | string | `nil` | Primary cnpg cluster port used for replica mode. |
+| cnpg.replica.host | string | `""` | Primary cnpg cluster host used for replica mode. |
+| cnpg.replica.port | int | `5432` | Primary cnpg cluster port used for replica mode. |
 | cnpg.username | string | `"dso"` | Username of the database user. |
 | config.create | bool | `false` | Whether or not helm should create the console config. |
 | config.name | string | `"dso-config"` | Name of the genrated config. |

--- a/charts/dso-console/templates/cnpg/backup-secret.yaml
+++ b/charts/dso-console/templates/cnpg/backup-secret.yaml
@@ -2,7 +2,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ .Values.cnpg.backup.s3Credentials.name | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+  name: {{ .Values.cnpg.backup.s3Credentials.secretName | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   labels:
     {{- include "cpnConsole.common.labels" . | nindent 4 }}
 data:

--- a/charts/dso-console/templates/cnpg/pg-cluster.yaml
+++ b/charts/dso-console/templates/cnpg/pg-cluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+  name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   labels:
     {{- include "cpnConsole.common.labels" . | nindent 4 }}
   annotations:
@@ -15,9 +15,6 @@ spec:
   imageName: {{ .Values.cnpg.imageName }}
   {{- end }}
   postgresql:
-    {{- if .Values.cnpg.imageName }}
-    image: {{ .Values.cnpg.imageName }}
-    {{- end }}
     parameters:
       max_worker_processes: "60"
     pg_hba:
@@ -28,29 +25,29 @@ spec:
     initdb:
       database: {{ .Values.cnpg.dbName }}
       owner: {{ .Values.cnpg.username }}
-  {{- else if eq .Values.cnpg.mode "replica" }}
+  {{- else if or (eq .Values.cnpg.mode "replica") (eq .Values.cnpg.mode "restore") }}
     recovery:
-      source: cluster-primary
-  replica:
-    enabled: true
-    source: cluster-primary
+      source: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   externalClusters:
-  - name: cluster-primary
-    {{- if .Values.cnpg.backup }}
+  - name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
+    {{- if or (.Values.cnpg.backup.enabled) (eq .Values.cnpg.mode "restore") }}
     barmanObjectStore:
       destinationPath: {{ .Values.cnpg.backup.destinationPath }}
       endpointURL: {{ .Values.cnpg.backup.endpointURL }}
+      {{- if .Values.cnpg.backup.endpointCA.name }}
       endpointCA:
         name: {{ .Values.cnpg.backup.endpointCA.name }}
         key: {{ .Values.cnpg.backup.endpointCA.key }}
+      {{- end }}
       s3Credentials:
         accessKeyId:
-          name: {{ .Values.cnpg.backup.s3Credentials.name | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+          name: {{ .Values.cnpg.backup.s3Credentials.secretName | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
           key: {{ .Values.cnpg.backup.s3Credentials.accessKeyId.key }}
         secretAccessKey:
-          name: {{ .Values.cnpg.backup.s3Credentials.name | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+          name: {{ .Values.cnpg.backup.s3Credentials.secretName | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
           key: {{ .Values.cnpg.backup.s3Credentials.secretAccessKey.key }}
     {{- end }}
+    {{- if eq .Values.cnpg.mode "replica" }}
     connectionParameters:
       host: {{ .Values.cnpg.replica.host }}
       port: {{ .Values.cnpg.replica.port }}
@@ -65,6 +62,12 @@ spec:
     sslRootCert:
       name: {{ (printf "%s-%s" .Values.cnpg.nameOverride "ca") | default (printf "%s-%s-%s" (include "cpnConsole.fullname" .) "pg-cluster" "ca") }}
       key: ca.crt
+    {{- end }}
+  {{- end }}
+  {{- if eq .Values.cnpg.mode "replica" }}
+  replica:
+    enabled: true
+    source: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   {{- end }}
   enableSuperuserAccess: {{ .Values.cnpg.enableSuperuserAccess }}
   primaryUpdateStrategy: {{ .Values.cnpg.primaryUpdateStrategy }}
@@ -80,10 +83,10 @@ spec:
         key: {{ .Values.cnpg.backup.endpointCA.key }}
       s3Credentials:
         accessKeyId:
-          name: {{ .Values.cnpg.backup.s3Credentials.name | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+          name: {{ .Values.cnpg.backup.s3Credentials.secretName | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
           key: {{ .Values.cnpg.backup.s3Credentials.accessKeyId.key }}
         secretAccessKey:
-          name: {{ .Values.cnpg.backup.s3Credentials.name | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+          name: {{ .Values.cnpg.backup.s3Credentials.secretName | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
           key: {{ .Values.cnpg.backup.s3Credentials.secretAccessKey.key }}
     retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy }}
   {{- end }}

--- a/charts/dso-console/templates/cnpg/scheduled-backup.yaml
+++ b/charts/dso-console/templates/cnpg/scheduled-backup.yaml
@@ -2,12 +2,12 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+  name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   labels:
     {{- include "cpnConsole.common.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.cnpg.backup.cron }}
   backupOwnerReference: self
   cluster:
-    name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+    name: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
 {{- end }}

--- a/charts/dso-console/templates/cnpg/service-nodeport.yaml
+++ b/charts/dso-console/templates/cnpg/service-nodeport.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ (printf "%s-%s" .Values.cnpg.nameOverride "rw-nodeport") | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+  name: {{ (printf "%s-%s" .Values.cnpg.nameOverride "rw-nodeport") | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
   labels:
     {{- include "cpnConsole.common.labels" . | nindent 4 }}
   annotations:
@@ -16,7 +16,7 @@ spec:
     protocol: TCP
     nodePort: {{ .Values.cnpg.nodePort }}
   selector:
-    cnpg.io/cluster: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" (include "cpnConsole.fullname" .) "pg-cluster") }}
+    cnpg.io/cluster: {{ .Values.cnpg.nameOverride | default (printf "%s-%s" "pg-cluster" (include "cpnConsole.fullname" .)) }}
     role: primary
   type: NodePort
 {{- end }}

--- a/charts/dso-console/values.yaml
+++ b/charts/dso-console/values.yaml
@@ -465,9 +465,13 @@ cnpg:
   # -- Whether or not cnpg cluster deployment should be enabled.
   enabled: false
   # -- Provide a name in place of the default cnpg cluster name.
+  # The cnpg operator adds the cluster name to S3's `destinationPath`, so it is necessary to provide the exact match of the main cluster when using `replica` or `restore` mode.
   nameOverride: &cnpgNameOverride ""
   # -- Number of instances to spawn in the cluster.
   instances: 3
+  # -- Name of the image used for database.
+  # By default (empty string), the operator will install the latest available minor version of the latest major version of PostgreSQL when the operator was released
+  imageName: ""
   # -- Username of the database user.
   username: "dso"
   # -- Name of the database.
@@ -486,13 +490,13 @@ cnpg:
   exposed: false
   # -- Port used for NodePort service. Needs `exposed` tu be true.
   nodePort:
-  # -- Mode used to deploy the cnpg cluster, it should be `primary` or `replica`.
+  # -- Mode used to deploy the cnpg cluster, it should be `primary`, `replica` or `restore`.
   mode: "primary"
   replica:
     # -- Primary cnpg cluster host used for replica mode.
-    host:
+    host: ""
     # -- Primary cnpg cluster port used for replica mode.
-    port:
+    port: 5432
   backup:
     # -- Whether or not cnpg cluster deployment should be enabled.
     enabled: false
@@ -510,16 +514,18 @@ cnpg:
       # It will use `name`, `accessKeyId.key`, `accessKeyId.value`, `secretAccessKey.key` and `secretAccessKey.value` to create the secret.
       create: false
       # -- S3 kuebernetes secret name used for cnpg backups.
-      name: *cnpgNameOverride
+      secretName: *cnpgNameOverride
       accessKeyId:
         # -- S3 accessKeyId kubernetes secret key used for cnpg backups.
         key: "accessKeyId"
         # -- S3 accessKeyId value used for cnpg backups.
+        # Only needed if `backup.s3Credentials.create` is set to `true`.
         value: ""
       secretAccessKey:
         # -- S3 secretAccessKey kubernetes secret key used for cnpg backups.
         key: "secretAccessKey"
         # -- S3 secretAccessKey value used for cnpg backups.
+        # Only needed if `backup.s3Credentials.create` is set to `true`.
         value: ""
     # -- The cron rule used for cnpg backups. By default it runs every 6 hours.
     cron: "0 0 */6 * * *"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les seuls mode cnpg disponibles sont `primary` et `replica`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Amélioration de la gestion du mode `replica` et ajout du mode `restore` qui permet de restaurer un cluster cnpg à partir de backups s3 plutôt qu'une initialisation depuis zéro de la base de donnée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
