### PR TITLE
feat: :sparkles: handle dedicated wal pvc for cnpg in console chart

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 1.9.1
+version: 1.10.0
 appVersion: 8.13.0
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.13.0](https://img.shields.io/badge/AppVersion-8.13.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.13.0](https://img.shields.io/badge/AppVersion-8.13.0-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 
@@ -109,10 +109,11 @@ A Helm chart to deploy Cloud Pi Native Console
 | cnpg.nameOverride | string | `""` | Provide a name in place of the default cnpg cluster name. The cnpg operator adds the cluster name to S3's `destinationPath`, so it is necessary to provide the exact match of the main cluster when using `replica` or `restore` mode. |
 | cnpg.nodePort | string | `nil` | Port used for NodePort service. Needs `exposed` tu be true. |
 | cnpg.primaryUpdateStrategy | string | `"unsupervised"` | Rolling update strategy used : unsupervised: automated update of the primary once all replicas have been upgraded (default) supervised: requires manual supervision to perform the switchover of the primary |
-| cnpg.pvcSize | string | `"10Gi"` | Size of the PVC used by each cnpg instance. |
+| cnpg.pvcSize | string | `"10Gi"` | Size of the data PVC used by each cnpg instance. |
 | cnpg.replica.host | string | `""` | Primary cnpg cluster host used for replica mode. |
 | cnpg.replica.port | int | `5432` | Primary cnpg cluster port used for replica mode. |
 | cnpg.username | string | `"dso"` | Username of the database user. |
+| cnpg.walPvcSize | string | `nil` | Size of the WAL PVC used by each cnpg instance (if value is `null` then WAL files are stored within the data PVC). |
 | config.create | bool | `false` | Whether or not helm should create the console config. |
 | config.name | string | `"dso-config"` | Name of the genrated config. |
 | config.projectsRootDir | string | `"forge"` | Projects root directory to use in other services such as Gitlab, etc. |

--- a/charts/dso-console/templates/cnpg/pg-cluster.yaml
+++ b/charts/dso-console/templates/cnpg/pg-cluster.yaml
@@ -78,6 +78,10 @@ spec:
   primaryUpdateStrategy: {{ .Values.cnpg.primaryUpdateStrategy }}
   storage:
     size: {{ .Values.cnpg.pvcSize }}
+  {{- if .Values.cnpg.walPvcSize }}
+  walStorage:
+    size: {{ .Values.cnpg.walPvcSize }}
+  {{- end }}
   {{- if .Values.cnpg.backup.enabled }}
   backup:
     barmanObjectStore:

--- a/charts/dso-console/values.yaml
+++ b/charts/dso-console/values.yaml
@@ -489,8 +489,10 @@ cnpg:
   # unsupervised: automated update of the primary once all replicas have been upgraded (default)
   # supervised: requires manual supervision to perform the switchover of the primary
   primaryUpdateStrategy: "unsupervised"
-  # -- Size of the PVC used by each cnpg instance.
+  # -- Size of the data PVC used by each cnpg instance.
   pvcSize: "10Gi"
+  # -- Size of the WAL PVC used by each cnpg instance (if value is `null` then WAL files are stored within the data PVC).
+  walPvcSize: null
   # -- Additional cnpg cluster annotations.
   annotations: {}
   # -- Additional cnpg cluster labels.


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les fichiers WAL sont stockés dans les même PVC que les données Postgres.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il est désormais possible de séparer le stockage des WAL dans un PVC distinct.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
