### PR TITLE
feat: :sparkles: add postgresWalMaxSlotKeepSize console chart values

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 1.11.11
+version: 1.12.0
 appVersion: 8.20.0
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 1.11.11](https://img.shields.io/badge/Version-1.11.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.0](https://img.shields.io/badge/AppVersion-8.20.0-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.0](https://img.shields.io/badge/AppVersion-8.20.0-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 
@@ -108,6 +108,7 @@ A Helm chart to deploy Cloud Pi Native Console
 | cnpg.mode | string | `"primary"` | Mode used to deploy the cnpg cluster, it should be `primary`, `replica` or `restore`. |
 | cnpg.nameOverride | string | `""` | Provide a name in place of the default cnpg cluster name. The cnpg operator adds the cluster name to S3's `destinationPath`, so it is necessary to provide the exact match of the main cluster when using `replica` or `restore` mode. |
 | cnpg.nodePort | string | `nil` | Port used for NodePort service. Needs `exposed` tu be true. |
+| cnpg.postgresWalMaxSlotKeepSize | string | `""` | Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time. Default retains an unlimited amount of WAL files. See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots (Refer to postgresql.conf for memory units). |
 | cnpg.primaryUpdateStrategy | string | `"unsupervised"` | Rolling update strategy used : unsupervised: automated update of the primary once all replicas have been upgraded (default) supervised: requires manual supervision to perform the switchover of the primary |
 | cnpg.pvcSize | string | `"10Gi"` | Size of the data PVC used by each cnpg instance. |
 | cnpg.replica.host | string | `""` | Primary cnpg cluster host used for replica mode. |

--- a/charts/dso-console/templates/cnpg/pg-cluster.yaml
+++ b/charts/dso-console/templates/cnpg/pg-cluster.yaml
@@ -20,6 +20,9 @@ spec:
   postgresql:
     parameters:
       max_worker_processes: "60"
+  {{- if .Values.cnpg.postgresWalMaxSlotKeepSize }}
+      max_slot_wal_keep_size: {{ .Values.cnpg.postgresWalMaxSlotKeepSize }}
+  {{- end }}
     pg_hba:
       - {{ printf "%s %s %s %s %s" "host" .Values.cnpg.dbName .Values.cnpg.username "all" "md5" }}
       - {{ printf "%s %s %s %s %s" "host" .Values.cnpg.dbName "streaming_replica" "all" "md5" }}

--- a/charts/dso-console/values.yaml
+++ b/charts/dso-console/values.yaml
@@ -498,6 +498,10 @@ cnpg:
   pvcSize: "10Gi"
   # -- Size of the WAL PVC used by each cnpg instance (if value is `null` then WAL files are stored within the data PVC).
   walPvcSize: null
+  # -- Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+  # Default retains an unlimited amount of WAL files.
+  # See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots (Refer to postgresql.conf for memory units).
+  postgresWalMaxSlotKeepSize: ""
   # -- Additional cnpg cluster annotations.
   annotations: {}
   # -- Additional cnpg cluster labels.


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Impossibilité de paramétrer `max_slot_wal_keep_size` pour le cluster CNPG de la console via Helm.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le paramétrage de `max_slot_wal_keep_size` peut se faire via `cnpg.postgresWalMaxSlotKeepSize` comme nous le faisons pour les autres clusters CNPG (Ansible Socle)

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
