### PR TITLE
fix: :bug: error when volume.projected.sources is null and not an empty array in console server `deployment.yaml`

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 2.1.5
+version: 2.1.6
 appVersion: 9.3.1
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.3.1](https://img.shields.io/badge/AppVersion-9.3.1-informational?style=flat-square)
+![Version: 2.1.6](https://img.shields.io/badge/Version-2.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.3.1](https://img.shields.io/badge/AppVersion-9.3.1-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 

--- a/charts/dso-console/templates/server/deployment.yaml
+++ b/charts/dso-console/templates/server/deployment.yaml
@@ -170,15 +170,15 @@ spec:
       {{- end }}
       volumes:
       - name: config
+        {{- if .Values.server.extraCa.name }}
         projected:
           sources:
-          {{- if .Values.server.extraCa.name }}
           - configMap:
               name: {{ .Values.server.extraCa.name }}
               items:
               - key: {{ .Values.server.extraCa.key }}
                 path: {{ .Values.server.extraCa.mountSubPath }}
-          {{- end }}
+        {{- end }}
       {{- if .Values.server.dbDataCm }}
       - name: imports
         configMap:


### PR DESCRIPTION
## Quel est le comportement actuel ?
Lorsqu'ArgoCD (de la Forge DSO) déploie la Console, tout ce passe comme prévu à l'exception de `dso-cpn-console-server` qui ne se déploie pas à cause d'une erreur dans le `deployment.yaml`.
> Failed sync attempt to 2.1.4: one or more objects failed to apply, reason: deployments.apps "dso-cpn-console-server" is forbidden: ValidatingAdmissionPolicy 'validating-node-p4sa-audience' with binding 'validating-node-p4sa-audience-binding' denied request: expression '!variables.podSpec.?volumes.orValue([]).exists( volume, has(volume.projected) && volume.projected.?sources.orValue([]).exists( source, has(source.serviceAccountToken) && has(source.serviceAccountToken.audience) && source.serviceAccountToken.audience == "https://container.cloud.google.com/v1/projects/<redacted_project_id>/locations/<region>/clusters/cluster-name/generateClusterNodeAgentToken"))' resulted in error: got 'types.Null', expected iterable type

Cette erreur n'est vraiment pas explicite donc voici une explication détaillée :
```yaml
    volumes:
      - name: config
        projected:
          sources:
          {{- if .Values.server.extraCa.name }}
          - configMap:
              name: {{ .Values.server.extraCa.name }}
              items:
              - key: {{ .Values.server.extraCa.key }}
                path: {{ .Values.server.extraCa.mountSubPath }}
          {{- end }}
      {{- if .Values.server.dbDataCm }}
      - name: imports
        ...
```
Dans mon cas devient :
```yaml
volumes:
  - name: config
    projected:
      sources: null # ⇐ "null" et non "[]"
```
Or, un volume `projected` sans aucune source n'a de toute façon pas de sens d'un point de vue fonctionnel.

Par ailleurs, cette erreur est possiblement spécifique à GKE (Autopilot) puisque, de ce que je comprends, il a des politiques de sécurité spécifiques, y compris la politique « validating-node-p4sa-audience » (celle qui rejette le déploiement).

## Quel est le nouveau comportement ?
Console server se déploie correctement (et aussi rapidement que le front-end (client)) et, une fois déployé, le manifeste du volume ressemble à ça :
```yaml
      volumes:
        - emptyDir: {}
          name: config
```

Par ailleurs, j'ai essayé d'englober tout le volume `config` sans réaliser que `volumeMounts` y faisait référence.
> one or more objects failed to apply, reason: Deployment.apps "dso-cpn-console-server" is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found: "config". Retrying attempt `#5`.

Ce serait possiblement plus propre de conditionner le volume mount et le volume `config` en entier, mais je n'ai pas essayé (`volumes` serait `null` ce qui pourrait poser problème).

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
J'ai essayé le déploiement en servant le dépôt helm sur mon dépot frok.