### PR TITLE
fix: :bug: podmonitor duplicate definition

### DIFF
--- a/charts/dso-cnpg/Chart.yaml
+++ b/charts/dso-cnpg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-cnpg
 description: A Helm Chart to deploy easily a CNPG cluster
 type: application
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.0.0
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-cnpg/README.md
+++ b/charts/dso-cnpg/README.md
@@ -1,6 +1,6 @@
 # cpn-cnpg
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 

--- a/charts/dso-cnpg/templates/_helpers.tpl
+++ b/charts/dso-cnpg/templates/_helpers.tpl
@@ -94,6 +94,7 @@ Selector labels
 {{- define "cpnCnpg.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "cpnCnpg.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+cnpg.io/cluster: {{ include "cpnCnpg.name" . }}
 {{- end }}
 
 

--- a/charts/dso-cnpg/templates/pg-cluster.yaml
+++ b/charts/dso-cnpg/templates/pg-cluster.yaml
@@ -126,5 +126,3 @@ spec:
       {{- end }}
     retentionPolicy: {{ .Values.backup.retentionPolicy }}
   {{- end }}
-  monitoring:
-    enablePodMonitor: {{ .Values.monitoring.enabled }} 


### PR DESCRIPTION
## Issues liées

Closes: https://github.com/cloud-pi-native/socle/issues/601

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Podmonitor enabling is defined twice : on the cluster kind and also in the template.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
We choose to keep the podmonitor defined by the template for now and add the inherited managed label.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No.