### PR TITLE
feat: :sparkles: add support for envFrom configuration

### DIFF
--- a/charts/dso-job/Chart.yaml
+++ b/charts/dso-job/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cpn-job
 description: Creates Job in Kubernetes cluster.
 type: application
-version: 1.0.0
-appVersion: 1.1.0
+version: 1.1.0
+appVersion: 1.0.0
 maintainers:
   - name: cloud-pi-native
     email: cloudpinative-relations@interieur.gouv.fr

--- a/charts/dso-job/README.md
+++ b/charts/dso-job/README.md
@@ -1,6 +1,6 @@
 # cpn-job
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Creates Job in Kubernetes cluster.
 
@@ -24,6 +24,7 @@ Creates Job in Kubernetes cluster.
 | job.backoffLimit | int | `6` | Number of retries before setting de Job status to failed. |
 | job.command | list | `[]` | Command to run in the job container. |
 | job.extraEnv | Optional | `[]` | Extra environment variables to pass to the job container. |
+| job.extraEnvFrom | Optional | `[]` | Extra environment variables to pass from secret or configmap to the job container. |
 | job.extraVolumeMounts | Optional | `[]` | Extra volume mounts for the job container. |
 | job.extraVolumes | Optional | `[]` | Extra volumes to mount into the job container. |
 | job.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the job image. |

--- a/charts/dso-job/templates/_helpers.tpl
+++ b/charts/dso-job/templates/_helpers.tpl
@@ -77,6 +77,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.job.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.job.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/dso-job/values.yaml
+++ b/charts/dso-job/values.yaml
@@ -43,6 +43,12 @@ job:
   extraEnv: []
   #   - name: MY_CUSTOM_VAR
   #     value: "custom-value"
+  # -- (Optional) Extra environment variables to pass from secret or configmap to the job container.
+  extraEnvFrom: []
+  #   - configMapRef:
+  #       name: custom-configmap
+  #   - secretRef:
+  #       name: custom-secret
   # -- (Optional) Extra volumes to mount into the job container.
   extraVolumes: []
   #   - name: my-random-volume


### PR DESCRIPTION
## Issues liées

Issues numéro: #161 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
We can support using secret or configmap to pass environment variables by setting
```yaml
  - env:       
    - name: DB_URL
      valueFrom:
        secretKeyRef:
          key: uri
          name: pg-cluster-console-app
```
But it is tedious when we have many environment variables.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Add support form envFrom configuration, so we can set like this.
```yaml
    envFrom:   
    - configMapRef:
        name: dso-cpn-console-server
    - secretRef:
        name: dso-cpn-console-server
```

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Test command:
```
helm template . \
  --set "job.extraEnvFrom[0].secretRef.name=dso-config"

```