### PR TITLE
Fix/grafana env vars support

### DIFF
--- a/charts/dso-grafana/Chart.yaml
+++ b/charts/dso-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dso-grafana
 description: This Helm chart deploy Grafana instances and default dashboards for each projects read from values file.
 type: application
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: grafana-operator
   repository: oci://ghcr.io/grafana/helm-charts

--- a/charts/dso-grafana/README.md
+++ b/charts/dso-grafana/README.md
@@ -1,6 +1,6 @@
 # dso-grafana
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This Helm chart deploy Grafana instances and default dashboards for each projects read from values file.
 

--- a/charts/dso-grafana/templates/grafana.yaml
+++ b/charts/dso-grafana/templates/grafana.yaml
@@ -135,6 +135,16 @@ spec:
     server:
       root_url: {{ printf "https://%s/%s/" $.Values.server.url .name }}
       serve_from_sub_path: "true"
+  {{- if $.Values.grafana.env }}
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              env:
+                {{- toYaml $.Values.grafana.env | nindent 14 }}
+  {{- end }}
   {{- if not $.Values.grafana.isOpenShift }}
   ingress:
     {{- if $.Values.server.certManager.enabled }}


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/841

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
We forgot there were 2 kind in the `charts/dso-grafana/templates/grafana.yaml` file.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Add support to pass env keys/values to the second grafana deployment container.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Also we are refactoring with if/else for Openshift values.

Test example :
```bash
helm template . --show-only templates/grafana.yaml --set grafana.env[0].name=HTTP_PROXY --set grafana.env[0].value=http://proxy.example.com:8080 --set grafana.env[1].name=HTTPS_PROXY --set grafana.env[1].value=http://proxy.example.com:8080
```