### PR TITLE
feat: :sparkles: allow enabled proxy for plugin initContainer only

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 2.1.16
+version: 2.2.0
 appVersion: 9.6.0
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 2.1.16](https://img.shields.io/badge/Version-2.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.6.0](https://img.shields.io/badge/AppVersion-9.6.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.6.0](https://img.shields.io/badge/AppVersion-9.6.0-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 
@@ -238,6 +238,8 @@ A Helm chart to deploy Cloud Pi Native Console
 | server.podAnnotations | object | `{}` | Annotations for the Console CPN server deployed pods. |
 | server.podLabels | object | `{}` | Labels for the Console CPN server deployed pods. |
 | server.podSecurityContext | object | `{}` | Toggle and define pod-level security context. |
+| server.proxy.enabled | bool | `false` | Enable Proxy configuration for the plugins initContainer. |
+| server.proxy.env | list | `[{"name":"http_proxy","value":"http://proxy.example.com:3128"},{"name":"https_proxy","value":"http://proxy.example.com:3128"},{"name":"no_proxy","value":".cluster.local,.svc.cluster.local,.svc"}]` | Map of environment variables to inject into the plugins initContainers. |
 | server.readinessProbe.enabled | bool | `true` | Whether or not enable the probe. |
 | server.readinessProbe.failureThreshold | int | `2` | Minimum consecutive failures for the probe to be considered failed after having succeeded. |
 | server.readinessProbe.initialDelaySeconds | int | `15` | Number of seconds after the container has started before probe is initiated. |

--- a/charts/dso-console/templates/server/deployment.yaml
+++ b/charts/dso-console/templates/server/deployment.yaml
@@ -41,6 +41,10 @@ spec:
       - image: {{ .Values.server.fetchContainer.image }}
         name: fetch-plugins
         imagePullPolicy: {{ .Values.server.fetchContainer.pullPolicy }}
+        {{- if .Values.server.proxy.enabled }}
+        env:
+          {{- toYaml .Values.server.proxy | nindent 8 }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "cpnConsole.fullname" . }}-server

--- a/charts/dso-console/values.yaml
+++ b/charts/dso-console/values.yaml
@@ -441,6 +441,17 @@ server:
   plugins: []
   # -- CSV list of plugins to disabled.
   disabledPlugins: ""
+  proxy:
+    # -- Enable Proxy configuration for the plugins initContainer.
+    enabled: false
+    # -- Map of environment variables to inject into the plugins initContainers.
+    env:
+    - name: http_proxy
+      value: "http://proxy.example.com:3128"
+    - name: https_proxy
+      value: "http://proxy.example.com:3128"
+    - name: no_proxy
+      value: ".cluster.local,.svc.cluster.local,.svc"
   resources:
     requests:
       # -- Memory request for the Console CPN server.


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
We are using exposed url for console to Socle services communication.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
We want Console to communicate with all Socle service directly since everything is in the same cluster.
Proxies won't be needed anymore for client and server console, but we might still need proxies for the plugins initContainer.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Test command:
```
helm template . --show-only templates/server/configmap.yaml --show-only templates/server/deployment.yaml --set server.proxy.enabled=true --set server.plugins.test=test
```

All PR related to https://github.com/cloud-pi-native/socle/issues/765 must be merged at the same time.
