### PR TITLE
Use nginx-strangler as console client backend

### DIFF
--- a/charts/dso-console/Chart.yaml
+++ b/charts/dso-console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cpn-console
 description: A Helm chart to deploy Cloud Pi Native Console
 type: application
-version: 2.3.8
+version: 2.4.0
 appVersion: 9.16.1
 keywords: []
 home: https://cloud-pi-native.fr

--- a/charts/dso-console/README.md
+++ b/charts/dso-console/README.md
@@ -1,6 +1,6 @@
 # cpn-console
 
-![Version: 2.3.8](https://img.shields.io/badge/Version-2.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.16.1](https://img.shields.io/badge/AppVersion-9.16.1-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.16.1](https://img.shields.io/badge/AppVersion-9.16.1-informational?style=flat-square)
 
 A Helm chart to deploy Cloud Pi Native Console
 

--- a/charts/dso-console/templates/backend/deployment.yaml
+++ b/charts/dso-console/templates/backend/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - sh
         - /script/fetch
         volumeMounts:
-        - name: fetch-script
+        - name: fetch-script-backend
           mountPath: /script
         - name: plugins
           mountPath: /plugins
@@ -194,9 +194,9 @@ spec:
       {{- if and .Values.backend.plugins (len .Values.backend.plugins) }}
       - name: plugins
         emptyDir: {}
-      - name: fetch-script
+      - name: fetch-script-backend
         configMap:
-          name: {{ include "cpnConsole.fullname" . }}-fetch-script
+          name: {{ include "cpnConsole.fullname" . }}-fetch-script-backend
       {{- end }}
       {{- range $volume := .Values.backend.extraVolumes }}
       - name: {{ $volume.name }}

--- a/charts/dso-console/templates/client/configmap.yaml
+++ b/charts/dso-console/templates/client/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{- include "cpnConsole.client.labels" . | nindent 4 }}
 data:
   SERVER_HOST: {{ include "cpnConsole.fullname" . }}-server
-  SERVER_PORT: {{ .Values.server.service.port | quote }}
+  SERVER_PORT: {{ .Values.strangler.service.port | quote }}
   KEYCLOAK_PROTOCOL: {{ .Values.global.keycloak.protocol.frontend }}
   KEYCLOAK_DOMAIN: {{ .Values.global.keycloak.domain.frontend }}
   KEYCLOAK_REALM: {{ .Values.global.keycloak.realm }}

--- a/charts/dso-console/templates/server/deployment.yaml
+++ b/charts/dso-console/templates/server/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - sh
         - /script/fetch
         volumeMounts:
-        - name: fetch-script
+        - name: fetch-script-server
           mountPath: /script
         - name: plugins
           mountPath: /plugins
@@ -194,9 +194,9 @@ spec:
       {{- if and .Values.server.plugins (len .Values.server.plugins) }}
       - name: plugins
         emptyDir: {}
-      - name: fetch-script
+      - name: fetch-script-server
         configMap:
-          name: {{ include "cpnConsole.fullname" . }}-fetch-script
+          name: {{ include "cpnConsole.fullname" . }}-fetch-script-server
       {{- end }}
       {{- range $volume := .Values.server.extraVolumes }}
       - name: {{ $volume.name }}


### PR DESCRIPTION
Dernière étape dans la mise en place du `nginx-strangler`: l'utiliser comme backend pour `client` au lieu de `server`.

(Je ne mergerai cette MR qu'une fois qu'on aura réglé les problèmes liés à Gitlab)