### PR TITLE
Change ingress path type to compatible one

### DIFF
--- a/charts/dso-grafana/templates/grafana.yaml
+++ b/charts/dso-grafana/templates/grafana.yaml
@@ -64,7 +64,7 @@ spec:
         http:
           paths:
           - path: "/{{ printf "%s-%s" $env $project.projectName }}"
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: "{{ printf "%s-%s" $env $project.projectName }}-grafana-service"


### PR DESCRIPTION
The pathType for the ingress set to `ImplementationSpecific` causes issues when the ingress used is not nginx

## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
