### PR TITLE
Allow custom Ingress path type 

### DIFF
--- a/charts/dso-grafana/Chart.yaml
+++ b/charts/dso-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dso-grafana
 description: This Helm chart deploy Grafana instances and default dashboards for each projects read from values file.
 type: application
-version: 1.7.0
+version: 1.8.0
 dependencies:
 - name: grafana-operator
   repository: oci://ghcr.io/grafana/helm-charts

--- a/charts/dso-grafana/README.md
+++ b/charts/dso-grafana/README.md
@@ -1,6 +1,6 @@
 # dso-grafana
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This Helm chart deploy Grafana instances and default dashboards for each projects read from values file.
 
@@ -35,9 +35,10 @@ This Helm chart deploy Grafana instances and default dashboards for each project
 | oauth.secret | string | `""` | Shared secret to autorize OAuth usage |
 | oauth.url | string | `"https://grafana.example.com/realms/dso"` | URL of the Idp provider to use |
 | projects | list | `[{"envs":{"hprod":{"groups":["Editors","Viewers"]},"prod":{"groups":["Editors","Viewers"]}},"projectName":"console","projectRepository":{"path":".","url":"https://gitlab.com/project/infra-observability.git"}}]` | Default list of sample projects. One Grafana instance is created for each item. This is list is overriden by the global.projects list if provided. |
-| server | object | `{"certManager":{"enabled":true},"ingressClassName":"nginx","url":"grafana.example.com"}` | Ingress server configuration |
+| server | object | `{"certManager":{"enabled":true},"ingressClassName":"nginx","ingressPathType":"ImplementationSpecific","url":"grafana.example.com"}` | Ingress server configuration |
 | server.certManager | object | `{"enabled":true}` | Enabling cert manager configuration |
 | server.ingressClassName | string | `"nginx"` | Class name of the ingress controller to use |
+| server.ingressPathType | string | `"ImplementationSpecific"` | Ingress path type to use for routing. Some ingress class controllers (e.g. Apisix), does not support `ImplementationSpecific` so we make it the default, but be optionally overridable. |
 | server.url | string | `"grafana.example.com"` | Url of the ingress frontend. The instance is reachable with a /<name> context. |
 
 ----------------------------------------------

--- a/charts/dso-grafana/templates/grafana.yaml
+++ b/charts/dso-grafana/templates/grafana.yaml
@@ -64,7 +64,7 @@ spec:
         http:
           paths:
           - path: "/{{ printf "%s-%s" $env $project.projectName }}"
-            pathType: ImplementationSpecific
+            pathType: {{ $.Values.server.ingressPathType }}
             backend:
               service:
                 name: "{{ printf "%s-%s" $env $project.projectName }}-grafana-service"

--- a/charts/dso-grafana/values.yaml
+++ b/charts/dso-grafana/values.yaml
@@ -45,6 +45,10 @@ server:
     enabled: true
   # -- Class name of the ingress controller to use
   ingressClassName: nginx
+  # -- Ingress path type to use for routing.
+  # Some ingress class controllers (e.g. Apisix), does not support `ImplementationSpecific`
+  # so we make it the default, but be optionally overridable.
+  ingressPathType: ImplementationSpecific
   # -- Url of the ingress frontend. The instance is reachable with a /<name> context.
   url: "grafana.example.com"
 


### PR DESCRIPTION
Suite de la MR: https://github.com/cloud-pi-native/helm-charts/pull/229

Objectif: Rendre customisable le `pathType` de l'Ingress Grafana, afin de permettre à d'autres Ingress Controller de pouvoir implémenter les règles de routage avec autre chose que `ImplementationSpecific` (qui reste cependant la valeur par défaut)