### PR TITLE
feat: 🧑‍💻support des dossiers Grafana

### DIFF
--- a/charts/dso-observability/Chart.yaml
+++ b/charts/dso-observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dso-observability
 description: A Helm chart for Kubernetes to deploy custom GrafanaDashboard and PrometheusRule
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: "0.0.1"
 maintainers:
   - name: cloud-pi-native

--- a/charts/dso-observability/README.md
+++ b/charts/dso-observability/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes to deploy custom GrafanaDashboard and PrometheusRule
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 ## Description
 
@@ -21,17 +21,18 @@ version: 0.1.0
 appVersion: "0.0.1"
 dependencies:
   - name: dso-observability
-    version: 0.1.8
+    version: 0.2.0
     repository: https://cloud-pi-native.github.io/helm-charts
 ```
 
 2- Create a file in your `template/` directory calling the two functions:
 ```yaml
+{{- include "grafana-dashboards.folders" . -}} # optionnal
 {{- include "grafana-dashboards.dashboards" . -}}
 {{- include "grafana-dashboards.rules" . -}}
 ```
 
-3- Add json et tpl files in `files/dashboards` and `files/rules` directories.
+3- Add json & tpl files in `files/dashboards` and `files/rules` directories.
 
 4- Add in your `values.yaml` file the value corresponding to the `app` label of your grafana instance:
 ```yaml

--- a/charts/dso-observability/README.md.gotmpl
+++ b/charts/dso-observability/README.md.gotmpl
@@ -26,11 +26,12 @@ dependencies:
 
 2- Create a file in your `template/` directory calling the two functions:
 ```yaml
+{{"{{"}}- include "grafana-dashboards.folders" . -}} # optionnal
 {{"{{"}}- include "grafana-dashboards.dashboards" . -}}
 {{"{{"}}- include "grafana-dashboards.rules" . -}}
 ```
 
-3- Add json et tpl files in `files/dashboards` and `files/rules` directories.
+3- Add json & tpl files in `files/dashboards` and `files/rules` directories.
 
 4- Add in your `values.yaml` file the value corresponding to the `app` label of your grafana instance:
 ```yaml

--- a/charts/dso-observability/templates/_dashboards.yaml
+++ b/charts/dso-observability/templates/_dashboards.yaml
@@ -1,55 +1,4 @@
-# implémente les règles de nommage des objets Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-# (caractères alphanumériques minscules, et tirets / points)
-# les noms des objets proviennent de noms de fichiers, donc il faut faire un peu de nettoyage:
-#
-# * un 1e replace/lower effectue des transformations (notez les parenthèses)
-# * ensuite le regexReplaceAllLiteral efface les caractères non valides
-# * enfin le trunc limite la taille à 253
-{{- define "lib.grafana-dns-name" }}
-{{- regexReplaceAllLiteral "[^a-z0-9\\-\\.]" ( . | lower | replace " " "-" | replace "_" "-") "" | trunc 253 }}
-{{- end }}
-
 {{- define "grafana-dashboards.dashboards" -}}
-{{/* ce bloc de code permet de gérer des arboresences de dossiers imbriqués */}}
-{{- $paths := dict }}{{/* on commence par se créer un tableau de correspondance entre un nom de dossier et son parent */}}
-{{- range $path, $_ := $.Files.Glob "files/dashboards/**.json" }}
-    {{- $path = $path | replace "files/dashboards/" "" | dir }}{{/* on récupère le chemin interne et on coupe le nom du fichier -> dossier/sous-dossier */}}
-    {{- if ne $path "." }}{{/* valeur pour le dossier racine, à ignorer */}}
-      {{- $liste := regexSplit "/" $path -1 | reverse }}{{/* on liste l'arboresence à l'envers -> [sous-dossier,dossier] */}}
-      {{- $parent := "" }}
-      {{- range $index, $name := $liste }}
-        {{- if lt ($index|add 1) ($liste | len) }}{{/* condition pour le dernier élément (racine) */}}
-          {{- $parent = index $liste ($index | add 1) -}}{{/* le dossier i+1 est le parent du dossier i */}}
-        {{- else }}
-          {{- $parent = "" }}{{/* sert de valeur "nil" */}}
-        {{- end }}
-        {{- $_ := set $paths . $parent }}{{/* assignation dans le dictionnaire. les doublons sont ignorés */}}
-      {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- range $name, $parent := $paths }}{{/* on itère le dictionnaire créé précédemment */}}
----
-# https://grafana.github.io/grafana-operator/docs/api/#grafanafolder
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaFolder
-metadata:
-  name: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" $name }}
-  labels:
-    tenant_id: {{ $.Values.global.tenantId }}
-spec:
-  allowCrossNamespaceImport: true
-  resyncPeriod: {{ $.Values.global.resyncPeriod | default "30s" }}
-  instanceSelector:
-    matchLabels:
-      app: {{ $.Values.global.tenantId }}
-  title: {{ $name }}{{/* contrairement au nom de la ressource, ici on peut avoir des majuscules, espaces, accents ... */}}
-  {{- with $parent }}{{/* on spécifie le dossier parent uniquement s'il existe ("" est traité comme null) */}}
-  parentFolderRef: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" . }}
-  {{- end }}
-{{ end }}
-
-
 {{ range $path, $_ := $.Files.Glob "files/dashboards/**.json" }}{{/* la double étoile permet de récupérer les ressources dans des dossiers imbriqués */}}
 {{ $folder := $path | replace "files/dashboards/" "" | dir }}
 {{ $parent := regexSplit "/" $folder -1 |reverse | first }}{{/* par rapport au fichier c'est le dossier grand-parent */}}
@@ -73,6 +22,7 @@ spec:
   {{- end }}
   json: >
 {{ $.Files.Get $path | indent 4 }}
-{{ end }}
-{{ end }}
+
+{{- end }}
+{{- end }}
 

--- a/charts/dso-observability/templates/_dashboards.yaml
+++ b/charts/dso-observability/templates/_dashboards.yaml
@@ -1,19 +1,78 @@
+# implémente les règles de nommage des objets Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+# (caractères alphanumériques minscules, et tirets / points)
+# les noms des objets proviennent de noms de fichiers, donc il faut faire un peu de nettoyage:
+#
+# * un 1e replace/lower effectue des transformations (notez les parenthèses)
+# * ensuite le regexReplaceAllLiteral efface les caractères non valides
+# * enfin le trunc limite la taille à 253
+{{- define "lib.grafana-dns-name" }}
+{{- regexReplaceAllLiteral "[^a-z0-9\\-\\.]" ( . | lower | replace " " "-" | replace "_" "-") "" | trunc 253 }}
+{{- end }}
+
 {{- define "grafana-dashboards.dashboards" -}}
-{{- range $path, $_ := $.Files.Glob "files/dashboards/*.json" }}
+{{/* ce bloc de code permet de gérer des arboresences de dossiers imbriqués */}}
+{{- $paths := dict }}{{/* on commence par se créer un tableau de correspondance entre un nom de dossier et son parent */}}
+{{- range $path, $_ := $.Files.Glob "files/dashboards/**.json" }}
+    {{- $path = $path | replace "files/dashboards/" "" | dir }}{{/* on récupère le chemin interne et on coupe le nom du fichier -> dossier/sous-dossier */}}
+    {{- if ne $path "." }}{{/* valeur pour le dossier racine, à ignorer */}}
+      {{- $liste := regexSplit "/" $path -1 | reverse }}{{/* on liste l'arboresence à l'envers -> [sous-dossier,dossier] */}}
+      {{- $parent := "" }}
+      {{- range $index, $name := $liste }}
+        {{- if lt ($index|add 1) ($liste | len) }}{{/* condition pour le dernier élément (racine) */}}
+          {{- $parent = index $liste ($index | add 1) -}}{{/* le dossier i+1 est le parent du dossier i */}}
+        {{- else }}
+          {{- $parent = "" }}{{/* sert de valeur "nil" */}}
+        {{- end }}
+        {{- $_ := set $paths . $parent }}{{/* assignation dans le dictionnaire. les doublons sont ignorés */}}
+      {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- range $name, $parent := $paths }}{{/* on itère le dictionnaire créé précédemment */}}
 ---
+# https://grafana.github.io/grafana-operator/docs/api/#grafanafolder
 apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDashboard
+kind: GrafanaFolder
 metadata:
-  name: {{ $.Values.global.tenantId }}-{{ $path | base | replace ".json"  "" }}
+  name: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" $name }}
   labels:
     tenant_id: {{ $.Values.global.tenantId }}
 spec:
   allowCrossNamespaceImport: true
-  resyncPeriod: 30s
+  resyncPeriod: {{ $.Values.global.resyncPeriod | default "30s" }}
   instanceSelector:
     matchLabels:
       app: {{ $.Values.global.tenantId }}
+  title: {{ $name }}{{/* contrairement au nom de la ressource, ici on peut avoir des majuscules, espaces, accents ... */}}
+  {{- with $parent }}{{/* on spécifie le dossier parent uniquement s'il existe ("" est traité comme null) */}}
+  parentFolderRef: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" . }}
+  {{- end }}
+{{ end }}
+
+
+{{ range $path, $_ := $.Files.Glob "files/dashboards/**.json" }}{{/* la double étoile permet de récupérer les ressources dans des dossiers imbriqués */}}
+{{ $folder := $path | replace "files/dashboards/" "" | dir }}
+{{ $parent := regexSplit "/" $folder -1 |reverse | first }}{{/* par rapport au fichier c'est le dossier grand-parent */}}
+{{ $name := $path | base | replace ".json" "" }}
+---
+# https://grafana.github.io/grafana-operator/docs/api/#grafanadashboard
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" $name }}
+  labels:
+    tenant_id: {{ $.Values.global.tenantId }}
+spec:
+  allowCrossNamespaceImport: true
+  resyncPeriod: {{ $.Values.global.resyncPeriod | default "30s" }}
+  instanceSelector:
+    matchLabels:
+      app: {{ $.Values.global.tenantId }}
+  {{- if ne $folder "." }}{{/* si le fichier n'est pas dans le dossier racine, alors on spécifie son dossier parent */}}
+  folderRef: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" $parent }}
+  {{- end }}
   json: >
 {{ $.Files.Get $path | indent 4 }}
-{{- end }}
-{{- end -}}
+{{ end }}
+{{ end }}
+

--- a/charts/dso-observability/templates/_folders.yaml
+++ b/charts/dso-observability/templates/_folders.yaml
@@ -1,0 +1,47 @@
+# tout ce template permet de gérer une arboresence de dossiers imbriquées
+# en créant une ressource GrafanaFolder, on dispose de plus de contrôle et de liberté sur le nom affiché dans grafana
+# les noms de ressources kubernetes sont assez limités pour du français, contrairemnt aux noms de dossiers Grafana
+
+# les dossiers & dashboard référencent leur parent avec le paramètre `parentFolderRef` / `folderRef`
+{{- define "grafana-dashboards.folders" -}}
+
+{{/* ce bloc de code permet de gérer des arboresences de dossiers imbriqués */}}
+{{- $paths := dict }}{{/* on commence par se créer un tableau de correspondance entre un nom de dossier et son parent */}}
+{{- range $path, $_ := $.Files.Glob "files/dashboards/**.json" }}
+    {{- $path = $path | replace "files/dashboards/" "" | dir }}{{/* on récupère le chemin interne et on coupe le nom du fichier -> dossier/sous-dossier */}}
+    {{- if ne $path "." }}{{/* valeur pour le dossier racine, à ignorer */}}
+      {{- $liste := regexSplit "/" $path -1 | reverse }}{{/* on liste l'arboresence à l'envers -> [sous-dossier,dossier,...] */}}
+      {{- $parent := "" }}
+      {{- range $index, $name := $liste }}
+        {{- if lt ($index|add 1) ($liste | len) }}{{/* condition pour le dernier élément (racine) */}}
+          {{- $parent = index $liste ($index | add 1) -}}{{/* le dossier i+1 est le parent du dossier i */}}
+        {{- else }}
+          {{- $parent = "" }}{{/* sert de valeur "nil" */}}
+        {{- end }}
+        {{- $_ := set $paths . $parent }}{{/* assignation dans le dictionnaire. les doublons sont ignorés */}}
+      {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- range $name, $parent := $paths }}{{/* on itère le dictionnaire créé précédemment */}}
+---
+# https://grafana.github.io/grafana-operator/docs/api/#grafanafolder
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" $name }}
+  labels:
+    tenant_id: {{ $.Values.global.tenantId }}
+spec:
+  allowCrossNamespaceImport: true
+  resyncPeriod: {{ $.Values.global.resyncPeriod | default "30s" }}
+  instanceSelector:
+    matchLabels:
+      app: {{ $.Values.global.tenantId }}
+  title: {{ $name }}{{/* contrairement au nom de la ressource, ici on peut avoir des majuscules, espaces, accents ... */}}
+  {{- with $parent }}{{/* on spécifie le dossier parent uniquement s'il existe ("" est traité comme null) */}}
+  parentFolderRef: {{ $.Values.global.tenantId }}-{{ include "lib.grafana-dns-name" . }}
+  {{- end }}
+{{ end }}
+
+{{ end }}

--- a/charts/dso-observability/templates/_helpers.tpl
+++ b/charts/dso-observability/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+# implémente les règles de nommage des objets Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+# (caractères alphanumériques minscules, et tirets / points)
+# les noms des objets proviennent de noms de fichiers, donc il faut faire un peu de nettoyage:
+#
+# * un 1e replace/lower effectue des transformations (notez les parenthèses)
+# * ensuite le regexReplaceAllLiteral efface les caractères non valides
+# * enfin le trunc limite la taille à 253
+{{- define "lib.grafana-dns-name" }}
+{{- regexReplaceAllLiteral "[^a-z0-9\\-\\.]" ( . | lower | replace " " "-" | replace "_" "-") "" | trunc 253 }}
+{{- end }}


### PR DESCRIPTION
## Quel est le comportement actuel ?
tous les dashboards tombent dans le même dossier sur Grafana

## Quel est le nouveau comportement ?
avec cette modification, si on crée des dossiers dans le repo Git, on les retrouve sur Grafana. Ça gère même des dossiers imbriqués

le code a été testé avec des données de test et avec les dashboards SIV2, sur Grafana Operator `v5.24.0`

## Cette PR introduit-elle un breaking change ?
non: elle ajoute un nouveau template "folders" que les utilisateurs ne sont pas obligés d'utiliser à moins qu'ils n'aient de dashboards dans des dossiers (qui étaient précédemment ignorés par le chart, donc c'est très peu probable)

## Autres informations

je ne serai pas faché si vous refusez cette PR:
si vous trouvez que le code est trop complexe, il est possible de réduire la complexité en gérant uniquement un seul niveau de dossiers sans caractères spéciaux, avec le paramètre `folder` du kind *GrafanaDashboard* au lieu d'utiliser `folderRef`