### PR TITLE
feat(dso-env): support multi-source applications with external valueSources

### DIFF
--- a/charts/dso-env/Chart.yaml
+++ b/charts/dso-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dso-env
 description: Creates argocd Project and Applications to deploy DSO project repositories.
 type: application
-version: 1.8.0
+version: 1.9.0
 appVersion: 1.0.0
 maintainers:
   - name: this-is-tobi

--- a/charts/dso-env/README.md
+++ b/charts/dso-env/README.md
@@ -1,6 +1,6 @@
 # dso-env
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Creates argocd Project and Applications to deploy DSO project repositories.
 

--- a/charts/dso-env/templates/application-app.yaml
+++ b/charts/dso-env/templates/application-app.yaml
@@ -17,7 +17,33 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: {{ $.Values.argocd.project }}-app
-  source: 
+  {{- if .valueSources }}
+  {{- $externalSources := list }}
+  {{- range .valueSources }}
+    {{- if eq .type "external" }}
+      {{- $externalSources = append $externalSources . }}
+    {{- end }}
+  {{- end }}
+  sources:
+    - repoURL: {{ .repoURL }}
+      targetRevision: {{ .targetRevision }}
+      path: {{ .path }}
+      helm:
+        valueFiles:
+          {{- range .valueSources }}
+          {{- if eq .type "internal" }}
+          - {{ .path }}
+          {{- else if eq .type "external" }}
+          - ${{ .ref }}/{{ .path }}
+          {{- end }}
+          {{- end }}
+    {{- range $externalSources }}
+    - repoURL: {{ .repoURL }}
+      targetRevision: {{ .targetRevision }}
+      ref: {{ .ref }}
+    {{- end }}
+  {{- else }}
+  source:
     repoURL: {{ .repoURL }}
     targetRevision:  {{ .targetRevision }}
     path: {{ .path }}
@@ -25,6 +51,7 @@ spec:
     helm:
       valueFiles: {{ .valueFiles | toJson }}
     {{- end }}
+  {{- end }}
   destination:
     name: {{ $.Values.application.destination.name }}
     namespace: {{ $.Values.application.destination.namespace }}
@@ -35,5 +62,5 @@ spec:
       prune: true
       selfHeal: true
       allowEmpty: true
-  {{- end }}  
+  {{- end }}
 {{- end }}

--- a/charts/dso-env/templates/project-app.yaml
+++ b/charts/dso-env/templates/project-app.yaml
@@ -117,3 +117,10 @@ spec:
   {{- range .Values.application.sourceRepositories }}
     - {{ . }}
   {{- end }}
+  {{- range .Values.application.repositories }}
+    {{- range .valueSources }}
+      {{- if eq .type "external" }}
+    - {{ .repoURL }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/dso-env/values.yaml
+++ b/charts/dso-env/values.yaml
@@ -59,6 +59,7 @@ application:
   #   targetRevision: main
   #   path: '.'
   #   autosync: true
+  #   # -- Rétrocompatibilité : liste de fichiers de values internes (ignoré si valueSources est défini)
   #   valueFiles: []
   # - name: tuto-java-infra-helm
   #   id: b1f4d3e2-3c4b-4d5e-9f6a-7b8c9d0e1f2a
@@ -66,9 +67,19 @@ application:
   #   targetRevision: HEAD
   #   path: .
   #   autosync: false
-  #   valueFiles:
-  #     - values.yaml
-  #     - values-integ.yaml
+  #   # -- Liste ordonnée de sources de valeurs (interne ou externe).
+  #   # L'ordre détermine la priorité Helm (les dernières entrées ont la priorité la plus haute).
+  #   # Remplace valueFiles si défini.
+  #   valueSources:
+  #     - type: internal
+  #       path: values.yaml
+  #     - type: external
+  #       ref: infra-values
+  #       repoURL: https://gitlab.com/projects/org/demo/infra-values.git
+  #       targetRevision: HEAD
+  #       path: values-integ.yaml
+  #     - type: internal
+  #       path: values-overrides.yaml
 # -- Ensemble de paramètres de fonctionnalités - expérimental
 features:
   # -- Support des rôles affinés


### PR DESCRIPTION
## Issues liées

Issues numéro: [#2247](https://github.com/cloud-pi-native/console/issues/2247)
---------

## Quel est le comportement actuel ?

Le chart `dso-env` ne permet de définir les valeurs Helm d'une application qu'à partir de fichiers de values internes au dépôt de l'application, via le champ `valueFiles`. Chaque `Application` ArgoCD est générée avec une source unique (`source`), ce qui rend impossible l'utilisation de fichiers de values hébergés dans un dépôt externe.

## Quel est le nouveau comportement ?

Ajout du support des applications ArgoCD multi-sources via un nouveau champ `valueSources` :

- `valueSources` est une liste ordonnée de sources de valeurs, l'ordre déterminant la priorité Helm (les dernières entrées ont la priorité la plus élevée).
- Chaque source peut être de type `internal` (fichier de values dans le dépôt de l'application) ou `external` (fichier de values dans un dépôt Git distinct, référencé via `ref`, `repoURL`, `targetRevision` et `path`).
- Lorsqu'au moins une source externe est définie, l'`Application` est générée avec le bloc `sources` (multi-sources) et les dépôts externes sont automatiquement ajoutés en `ref`.
- Les dépôts externes utilisés dans les `valueSources` sont automatiquement ajoutés aux `sourceRepositories` du `Project` ArgoCD.
- Le champ `valueFiles` reste pris en charge pour la rétrocompatibilité et continue de générer une source unique lorsque `valueSources` n'est pas défini.

Version du chart mise à jour : `1.8.0` → `1.9.0`.

## Cette PR introduit-elle un breaking change ?

Non. Le champ existant `valueFiles` est conservé et reste pleinement fonctionnel. Le nouveau comportement multi-sources n'est activé que si le champ `valueSources` est explicitement défini. Les applications existantes ne sont pas impactées.

## Autres informations

Aucune.
