### PR TITLE
unify image, switch to mc, modernize velero options

### DIFF
--- a/charts/dso-backup/Chart.yaml
+++ b/charts/dso-backup/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   - Resources only: Backup Kubernetes resources without database
   - CNPG integrated: Orchestrate application shutdown + CNPG backup + Velero
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.0.0"
 keywords:
   - velero

--- a/charts/dso-backup/README.md
+++ b/charts/dso-backup/README.md
@@ -1,6 +1,6 @@
 # dso-backup
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for orchestrating Velero backups with different strategies:
 - Resources only: Backup Kubernetes resources without database
@@ -34,21 +34,16 @@ Generic Helm chart for orchestrating Velero backups with different strategies:
 | schedule.cron | string | `"0 2 * * *"` |  |
 | schedule.failedJobsHistoryLimit | int | `3` |  |
 | schedule.image.pullPolicy | string | `"IfNotPresent"` |  |
-| schedule.image.repository | string | `"bitnami/kubectl"` |  |
-| schedule.image.tag | string | `"latest"` |  |
+| schedule.image.repository | string | `"ghcr.io/cloud-pi-native/backup-tools"` |  |
+| schedule.image.tag | string | `""` |  |
 | schedule.successfulJobsHistoryLimit | int | `3` |  |
 | schedule.ttlSecondsAfterFinished | int | `3600` |  |
 | strategy | string | `"resources-only"` |  |
-| vault.image.pullPolicy | string | `"IfNotPresent"` |  |
-| vault.image.repository | string | `"amazon/aws-cli"` |  |
-| vault.image.tag | string | `"2.15.0"` |  |
 | vault.podLabelSelector."app.kubernetes.io/name" | string | `"vault"` |  |
 | vault.s3.bucket | string | `""` |  |
 | vault.s3.credentialsSecret | string | `""` |  |
 | vault.s3.endpoint | string | `""` |  |
-| vault.s3.forcePathStyle | bool | `false` |  |
 | vault.s3.prefix | string | `"vault-snapshots"` |  |
-| vault.s3.region | string | `"us-east-1"` |  |
 | vault.snapshotPath | string | `"/tmp/raft-snapshot.snap"` |  |
 | velero.backupTimeout | string | `"1800"` |  |
 | velero.namespace | string | `"infra-velero"` |  |
@@ -58,8 +53,9 @@ Generic Helm chart for orchestrating Velero backups with different strategies:
 | velero.resources.orLabelSelectors | list | `[]` |  |
 | velero.storageLocation | string | `"velero"` |  |
 | velero.ttl | string | `"336h"` |  |
-| velero.volumeSnapshotLocations | list | `[]` |  |
-| velero.volumes.defaultVolumesToRestic | bool | `false` |  |
+| velero.volumes.defaultVolumesToFsBackup | bool | `true` |  |
+| velero.volumes.snapshotLocations | list | `[]` |  |
+| velero.volumes.snapshotMoveData | bool | `false` |  |
 | velero.volumes.snapshotVolumes | bool | `false` |  |
 
 ----------------------------------------------

--- a/charts/dso-backup/templates/_helpers.tpl
+++ b/charts/dso-backup/templates/_helpers.tpl
@@ -98,23 +98,15 @@ Check if vault strategy is enabled
 
 {{/*
 Resolve the image used by the backup CronJob.
-For the vault strategy, vault.image overrides schedule.image because the
-default schedule image (bitnami/kubectl) lacks aws-cli.
+The image must bundle kubectl and mc (used by all strategies).
+Tag falls back to .Chart.AppVersion when not provided.
 */}}
 {{- define "dso-backup.image" -}}
-{{- if eq .Values.strategy "vault" -}}
-{{ .Values.vault.image.repository }}:{{ .Values.vault.image.tag }}
-{{- else -}}
-{{ .Values.schedule.image.repository }}:{{ .Values.schedule.image.tag }}
-{{- end -}}
+{{ .Values.schedule.image.repository }}:{{ .Values.schedule.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "dso-backup.imagePullPolicy" -}}
-{{- if eq .Values.strategy "vault" -}}
-{{ .Values.vault.image.pullPolicy }}
-{{- else -}}
 {{ .Values.schedule.image.pullPolicy }}
-{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/dso-backup/templates/configmap-vault-hooks.yaml
+++ b/charts/dso-backup/templates/configmap-vault-hooks.yaml
@@ -33,19 +33,17 @@ data:
     SNAPSHOT_PATH="{{ .Values.vault.snapshotPath }}"
     S3_BUCKET="${VAULT_S3_BUCKET}"
     S3_PREFIX="${VAULT_S3_PREFIX}"
-    S3_REGION="${VAULT_S3_REGION}"
-    S3_ENDPOINT="${VAULT_S3_ENDPOINT:-}"
-    S3_FORCE_PATH_STYLE="${VAULT_S3_FORCE_PATH_STYLE:-false}"
+    S3_ENDPOINT="${VAULT_S3_ENDPOINT}"
 
-    # Install kubectl on the fly if missing (the default image is amazon/aws-cli).
-    if ! command -v kubectl >/dev/null 2>&1; then
-      echo "Installing kubectl..."
-      KUBECTL_VERSION="$(curl -sL https://dl.k8s.io/release/stable.txt)"
-      curl -sLo /usr/local/bin/kubectl \
-        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-      chmod +x /usr/local/bin/kubectl
-      echo "  kubectl $(kubectl version --client --output=yaml | grep gitVersion | head -1)"
-    fi
+    for bin in kubectl mc; do
+      if ! command -v "${bin}" >/dev/null 2>&1; then
+        echo "ERROR: ${bin} not found in image. Use an image bundling kubectl + mc."
+        exit 1
+      fi
+    done
+
+    # Configure mc alias for the S3 destination.
+    mc alias set s3backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null
 
     # Step 1: discover the Vault leader pod.
     echo "Step 1: Locating Vault leader pod (selector: ${LABEL_SELECTOR})..."
@@ -79,21 +77,13 @@ data:
 
     # Step 3: stream the snapshot from the Vault pod to S3.
     SNAPSHOT_NAME="vault-${APP_NAME}-$(date -u +%Y%m%d-%H%M%S).snap"
+    S3_TARGET="s3backup/${S3_BUCKET}/${S3_PREFIX}/${SNAPSHOT_NAME}"
     S3_URI="s3://${S3_BUCKET}/${S3_PREFIX}/${SNAPSHOT_NAME}"
-
-    AWS_OPTS=(--region "${S3_REGION}")
-    if [ -n "${S3_ENDPOINT}" ]; then
-      AWS_OPTS+=(--endpoint-url "${S3_ENDPOINT}")
-    fi
-    if [ "${S3_FORCE_PATH_STYLE}" = "true" ]; then
-      export AWS_REQUEST_CHECKSUM_CALCULATION="when_required"
-      export AWS_RESPONSE_CHECKSUM_VALIDATION="when_required"
-    fi
 
     echo ""
     echo "Step 3: Uploading snapshot to ${S3_URI}..."
     kubectl exec -n "${NAMESPACE}" "${LEADER_POD}" -- cat "${SNAPSHOT_PATH}" \
-      | aws s3 cp - "${S3_URI}" "${AWS_OPTS[@]}"
+      | mc pipe "${S3_TARGET}"
 
     echo "  Upload completed"
 

--- a/charts/dso-backup/templates/configmap-velero-backup.yaml
+++ b/charts/dso-backup/templates/configmap-velero-backup.yaml
@@ -78,13 +78,14 @@ data:
       {{- end }}
 
       snapshotVolumes: {{ .Values.velero.volumes.snapshotVolumes }}
-      defaultVolumesToRestic: {{ .Values.velero.volumes.defaultVolumesToRestic }}
+      snapshotMoveData: {{ .Values.velero.volumes.snapshotMoveData }}
+      defaultVolumesToFsBackup: {{ .Values.velero.volumes.defaultVolumesToFsBackup }}
       ttl: ${TTL}
       storageLocation: ${STORAGE_LOCATION}
 
-      {{- if .Values.velero.volumeSnapshotLocations }}
+      {{- if .Values.velero.volumes.snapshotLocations }}
       volumeSnapshotLocations:
-      {{- toYaml .Values.velero.volumeSnapshotLocations | nindent 6 }}
+      {{- toYaml .Values.velero.volumes.snapshotLocations | nindent 6 }}
       {{- end }}
     EOF
 

--- a/charts/dso-backup/templates/cronjob-backup.yaml
+++ b/charts/dso-backup/templates/cronjob-backup.yaml
@@ -50,22 +50,18 @@ spec:
               value: {{ .Values.vault.s3.bucket | quote }}
             - name: VAULT_S3_PREFIX
               value: {{ .Values.vault.s3.prefix | quote }}
-            - name: VAULT_S3_REGION
-              value: {{ .Values.vault.s3.region | quote }}
             - name: VAULT_S3_ENDPOINT
               value: {{ .Values.vault.s3.endpoint | quote }}
-            - name: VAULT_S3_FORCE_PATH_STYLE
-              value: {{ .Values.vault.s3.forcePathStyle | quote }}
-            - name: AWS_ACCESS_KEY_ID
+            - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.vault.s3.credentialsSecret }}
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
+                  key: S3_ACCESS_KEY
+            - name: S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.vault.s3.credentialsSecret }}
-                  key: AWS_SECRET_ACCESS_KEY
+                  key: S3_SECRET_KEY
             {{- end }}
             resources:
               requests:

--- a/charts/dso-backup/templates/rbac.yaml
+++ b/charts/dso-backup/templates/rbac.yaml
@@ -34,7 +34,7 @@ rules:
 # Permissions for waiting on pods (no delete needed, just watch for termination)
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "watch"]
+  verbs: ["get", "list", "watch"]
 
 {{- if eq .Values.strategy "cnpg" }}
 # Permissions for CNPG Cluster (patch for annotations)

--- a/charts/dso-backup/values.yaml
+++ b/charts/dso-backup/values.yaml
@@ -35,10 +35,12 @@ schedule:
   # TTL for completed jobs (seconds)
   ttlSecondsAfterFinished: 3600  # 1 hour
 
-  # Container image for CronJob
+  # Container image for the backup CronJob.
+  # Bundles kubectl + mc (used by all strategies, including vault).
   image:
-    repository: "bitnami/kubectl"
-    tag: "latest"
+    repository: "ghcr.io/cloud-pi-native/backup-tools"
+    # Falls back to .Chart.AppVersion when empty.
+    tag: ""
     pullPolicy: "IfNotPresent"
 
 # Velero backup configuration
@@ -52,9 +54,6 @@ velero:
 
   # Storage location (BSL name)
   storageLocation: "velero"
-
-  # Volume snapshot locations
-  volumeSnapshotLocations: []
 
   # Timeout for Velero backup completion
   backupTimeout: "1800"
@@ -95,8 +94,14 @@ velero:
     # Snapshot PVs using cloud provider snapshots
     snapshotVolumes: false
 
-    # Use Restic for volume backups
-    defaultVolumesToRestic: false
+    # Move snapshot data to object storage (CSI snapshot data movement)
+    snapshotMoveData: false
+
+    # Use file system backup (node-agent) for volume backups
+    defaultVolumesToFsBackup: true
+
+    # Volume snapshot locations (VSL names)
+    snapshotLocations: []
 
 # CNPG configuration (only for strategy = "cnpg")
 cnpg:
@@ -115,30 +120,17 @@ vault:
   # (it is removed at the end of the pre-hook)
   snapshotPath: "/tmp/raft-snapshot.snap"
 
-  # S3 destination for the snapshot upload
+  # S3 destination for the snapshot upload (uses mc / MinIO client).
   s3:
     # Bucket name (required when strategy = vault)
     bucket: ""
     # Prefix (folder) within the bucket
     prefix: "vault-snapshots"
-    # S3 region
-    region: "us-east-1"
-    # Optional S3-compatible endpoint (Minio, Ceph, etc.). Leave empty for AWS S3.
+    # S3 endpoint URL — works for AWS S3, MinIO, Ceph, etc. (required)
     endpoint: ""
-    # Force path-style addressing (needed for most S3-compatible backends)
-    forcePathStyle: false
-    # Existing Secret containing AWS credentials. Must expose the keys
-    # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (required when strategy = vault).
+    # Existing Secret exposing keys S3_ACCESS_KEY and S3_SECRET_KEY
+    # (required when strategy = vault).
     credentialsSecret: ""
-
-  # Override the cronjob image for the vault strategy.
-  # Default image bundles aws-cli; kubectl is downloaded at runtime so the
-  # script needs egress to dl.k8s.io. Override with a custom image that
-  # already bundles both kubectl and aws-cli to avoid the download.
-  image:
-    repository: "amazon/aws-cli"
-    tag: "2.15.0"
-    pullPolicy: "IfNotPresent"
 
 # Application orchestration
 application:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
  Le chart dso-backup utilise deux images distinctes pour les jobs de backup :
  - bitnami/kubectl:latest pour les stratégies resources-only et cnpg
  - amazon/aws-cli:2.15.0 pour la stratégie vault, avec un download runtime de kubectl depuis dl.k8s.io

  Cette approche pose plusieurs problèmes :
  - Le pré-hook vault requiert un accès sortant vers dl.k8s.io pour installer kubectl au démarrage du job — bloquant sur les clusters air-gap
  - Les erreurs de download sont masquées par curl -s, rendant le diagnostic impossible (le job échoue silencieusement sur Installing kubectl…)
  - L'upload S3 utilise aws-cli avec les env AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, region, forcePathStyle
  - Le helper dso-backup.image porte une branche conditionnelle par stratégie

  Côté Velero, les valeurs par défaut utilisent defaultVolumesToRestic (déprécié depuis Velero 1.10) et volumeSnapshotLocations est déclaré à la racine de .velero.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
  - Image unique ghcr.io/cloud-pi-native/backup-tools pour tous les jobs, quelle que soit la stratégie. L'image bundle kubectl + mc (MinIO client). Plus aucun download
   runtime. 
  - Tag par défaut aligné sur .Chart.AppVersion si non spécifié par l'utilisateur ({{ .Values.schedule.image.tag | default .Chart.AppVersion }}).
  - Upload S3 via mc au lieu de aws-cli — compatible AWS S3, MinIO, Ceph sans configuration supplémentaire (plus besoin de region ni forcePathStyle).
  - Fail-fast explicite si kubectl ou mc manquent dans l'image, avec un message clair.
  - Helper simplifié : dso-backup.image et dso-backup.imagePullPolicy ne branchent plus sur la stratégie.
  - Options Velero modernisées :
    - defaultVolumesToRestic → defaultVolumesToFsBackup: true (nom actuel depuis Velero 1.10)
    - Ajout de snapshotMoveData: false (data movement CSI)
    - volumeSnapshotLocations déplacé sous velero.volumes.snapshotLocations pour regrouper les options de volumes

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
