### PR TITLE
fix: add velero prefix, S3 insecure flag, and vault token

### DIFF
--- a/charts/dso-backup/Chart.yaml
+++ b/charts/dso-backup/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   - Resources only: Backup Kubernetes resources without database
   - CNPG integrated: Orchestrate application shutdown + CNPG backup + Velero
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0.0"
 keywords:
   - velero

--- a/charts/dso-backup/README.md
+++ b/charts/dso-backup/README.md
@@ -1,6 +1,6 @@
 # dso-backup
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for orchestrating Velero backups with different strategies:
 - Resources only: Backup Kubernetes resources without database
@@ -43,8 +43,12 @@ Generic Helm chart for orchestrating Velero backups with different strategies:
 | vault.s3.bucket | string | `""` |  |
 | vault.s3.credentialsSecret | string | `""` |  |
 | vault.s3.endpoint | string | `""` |  |
+| vault.s3.insecure | bool | `false` |  |
 | vault.s3.prefix | string | `"vault-snapshots"` |  |
 | vault.snapshotPath | string | `"/tmp/raft-snapshot.snap"` |  |
+| vault.tokenSecret.key | string | `"VAULT_TOKEN"` |  |
+| vault.tokenSecret.name | string | `""` |  |
+| velero.backupNamePrefix | string | `""` |  |
 | velero.backupTimeout | string | `"1800"` |  |
 | velero.namespace | string | `"infra-velero"` |  |
 | velero.resources.exclude | list | `[]` |  |

--- a/charts/dso-backup/templates/configmap-vault-hooks.yaml
+++ b/charts/dso-backup/templates/configmap-vault-hooks.yaml
@@ -5,6 +5,9 @@
 {{- if not .Values.vault.s3.credentialsSecret }}
 {{- fail "vault.s3.credentialsSecret is required when strategy = vault" }}
 {{- end }}
+{{- if not .Values.vault.tokenSecret.name }}
+{{- fail "vault.tokenSecret.name is required when strategy = vault" }}
+{{- end }}
 ---
 # ConfigMap for Vault strategy hooks (conditional - only for vault strategy)
 apiVersion: v1
@@ -34,6 +37,7 @@ data:
     S3_BUCKET="${VAULT_S3_BUCKET}"
     S3_PREFIX="${VAULT_S3_PREFIX}"
     S3_ENDPOINT="${VAULT_S3_ENDPOINT}"
+    S3_INSECURE="${VAULT_S3_INSECURE:-false}"
 
     for bin in kubectl mc; do
       if ! command -v "${bin}" >/dev/null 2>&1; then
@@ -42,8 +46,13 @@ data:
       fi
     done
 
+    MC_OPTS=()
+    if [ "${S3_INSECURE}" = "true" ]; then
+      MC_OPTS+=(--insecure)
+    fi
+
     # Configure mc alias for the S3 destination.
-    mc alias set s3backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null
+    mc "${MC_OPTS[@]}" alias set s3backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" >/dev/null
 
     # Step 1: discover the Vault leader pod.
     echo "Step 1: Locating Vault leader pod (selector: ${LABEL_SELECTOR})..."
@@ -66,9 +75,12 @@ data:
     echo "  Using pod: ${LEADER_POD}"
 
     # Step 2: take the raft snapshot inside the Vault container.
+    # Token is passed via `env` so the snapshot API accepts the call
+    # (requires `sudo` capability on sys/storage/raft/snapshot).
     echo ""
     echo "Step 2: Creating raft snapshot at ${SNAPSHOT_PATH}..."
     kubectl exec -n "${NAMESPACE}" "${LEADER_POD}" -- \
+      env VAULT_TOKEN="${VAULT_TOKEN}" \
       vault operator raft snapshot save "${SNAPSHOT_PATH}"
 
     SNAPSHOT_SIZE="$(kubectl exec -n "${NAMESPACE}" "${LEADER_POD}" -- \
@@ -83,7 +95,7 @@ data:
     echo ""
     echo "Step 3: Uploading snapshot to ${S3_URI}..."
     kubectl exec -n "${NAMESPACE}" "${LEADER_POD}" -- cat "${SNAPSHOT_PATH}" \
-      | mc pipe "${S3_TARGET}"
+      | mc "${MC_OPTS[@]}" pipe "${S3_TARGET}"
 
     echo "  Upload completed"
 

--- a/charts/dso-backup/templates/cronjob-backup.yaml
+++ b/charts/dso-backup/templates/cronjob-backup.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.velero.ttl | quote }}
             - name: BACKUP_TIMEOUT
               value: {{ .Values.velero.backupTimeout | default "1800" | quote }}
+            - name: VELERO_BACKUP_NAME_PREFIX
+              value: {{ .Values.velero.backupNamePrefix | quote }}
             {{- if eq .Values.strategy "vault" }}
             - name: VAULT_S3_BUCKET
               value: {{ .Values.vault.s3.bucket | quote }}
@@ -52,6 +54,8 @@ spec:
               value: {{ .Values.vault.s3.prefix | quote }}
             - name: VAULT_S3_ENDPOINT
               value: {{ .Values.vault.s3.endpoint | quote }}
+            - name: VAULT_S3_INSECURE
+              value: {{ .Values.vault.s3.insecure | quote }}
             - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -62,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.vault.s3.credentialsSecret }}
                   key: S3_SECRET_KEY
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vault.tokenSecret.name }}
+                  key: {{ .Values.vault.tokenSecret.key }}
             {{- end }}
             resources:
               requests:

--- a/charts/dso-backup/templates/cronjob-scripts.yaml
+++ b/charts/dso-backup/templates/cronjob-scripts.yaml
@@ -30,6 +30,9 @@ data:
     export BACKUP_TIMEOUT="${BACKUP_TIMEOUT}"
 
     BACKUP_NAME="${APP_NAME}-$(date +%Y%m%d-%H%M%S)"
+    if [ -n "${VELERO_BACKUP_NAME_PREFIX:-}" ]; then
+      BACKUP_NAME="${VELERO_BACKUP_NAME_PREFIX}-${BACKUP_NAME}"
+    fi
     export VELERO_BACKUP_NAME="${BACKUP_NAME}"
 
     # Error handler

--- a/charts/dso-backup/values.yaml
+++ b/charts/dso-backup/values.yaml
@@ -55,6 +55,10 @@ velero:
   # Storage location (BSL name)
   storageLocation: "velero"
 
+  # Prefix prepended to the Velero Backup name.
+  # Final name: <prefix>-<appName>-YYYYMMDD-HHMMSS (empty prefix = no prefix).
+  backupNamePrefix: ""
+
   # Timeout for Velero backup completion
   backupTimeout: "1800"
 
@@ -120,6 +124,14 @@ vault:
   # (it is removed at the end of the pre-hook)
   snapshotPath: "/tmp/raft-snapshot.snap"
 
+  # Existing Secret providing the Vault token used by the raft snapshot API.
+  # The token must have `sudo` capability on `sys/storage/raft/snapshot`.
+  tokenSecret:
+    # Secret name (required when strategy = vault)
+    name: ""
+    # Key holding the token value
+    key: "VAULT_TOKEN"
+
   # S3 destination for the snapshot upload (uses mc / MinIO client).
   s3:
     # Bucket name (required when strategy = vault)
@@ -131,6 +143,8 @@ vault:
     # Existing Secret exposing keys S3_ACCESS_KEY and S3_SECRET_KEY
     # (required when strategy = vault).
     credentialsSecret: ""
+    # Skip TLS certificate verification for the S3 endpoint (self-signed certs).
+    insecure: false
 
 # Application orchestration
 application:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
 - Le nom du Backup Velero créé par le CronJob est figé au format <appName>-YYYYMMDD-HHMMSS. Impossible de préfixer les backups d'un même cluster
  - Le hook Vault communique avec l'endpoint S3 via mc, mais sans option pour désactiver la vérification TLS. Sur un endpoint S3 auto-signé (MinIO interne, Ceph avec
  cert interne), l'upload du snapshot échoue avec une erreur de certificat.
  - Lors du snapshot raft (vault operator raft snapshot save), aucun token n'est passé à la commande vault exécutée dans le pod. L'API sys/storage/raft/snapshot répond
   alors 403 Forbidden car elle exige la capability sudo sur ce path.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
  - Nouvelle value velero.backupNamePrefix (défaut ""). Quand renseignée, le nom du Backup devient <prefix>-<appName>-YYYYMMDD-HHMMSS. Injectée en env
  VELERO_BACKUP_NAME_PREFIX dans le CronJob et appliquée dans l'orchestrateur.
  - Nouvelle value vault.s3.insecure (défaut false). Quand true, l'option --insecure est ajoutée à toutes les invocations mc (alias set + pipe), permettant l'upload
  vers un endpoint S3 auto-signé.
  - Nouveau bloc vault.tokenSecret (name + key, clé par défaut VAULT_TOKEN). Référence un Secret K8s existant contenant un token Vault avec la policy adéquate. Le
  token est injecté en env VAULT_TOKEN dans le CronJob, puis relayé au binaire vault via env VAULT_TOKEN=... vault operator raft snapshot save. Validation Helm (fail)
  si tokenSecret.name est vide alors que strategy = vault.
  - Policy Vault requise pour ce token :
  path "sys/storage/raft/snapshot" {
    capabilities = ["read", "sudo"]
  }
  - Pas de breaking change : les trois nouvelles values ont des défauts qui reproduisent le comportement précédent, sauf vault.tokenSecret.name qui devient obligatoire
   pour la stratégie vault (mais sans lui le snapshot renvoyait déjà 403).
  
## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
