### PR TITLE
revert: app name max size truncation from PR #232

### DIFF
--- a/charts/dso-env/Chart.yaml
+++ b/charts/dso-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dso-env
 description: Creates argocd Project and Applications to deploy DSO project repositories.
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.0.0
 maintainers:
   - name: this-is-tobi

--- a/charts/dso-env/README.md
+++ b/charts/dso-env/README.md
@@ -1,6 +1,6 @@
 # dso-env
 
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Creates argocd Project and Applications to deploy DSO project repositories.
 

--- a/charts/dso-env/templates/application-app.yaml
+++ b/charts/dso-env/templates/application-app.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ printf "%s-%s-%s" $.Values.argocd.project .name (sha1sum .repoURL | trunc 4) | trunc 63 | trimSuffix "-" }}
+  name: {{ $.Values.argocd.project }}-{{ .name }}-{{ sha1sum .repoURL | trunc 4 }}
   namespace: {{ $.Values.argocd.namespace }}
   labels:
     app.kubernetes.io/managed-by: dso-console


### PR DESCRIPTION
## Issues liées

Issues numéro: cloud-pi-native/socle#1006

---------

## Quel est le comportement actuel ?
La PR #232 tronque le `metadata.name` des applications ArgoCD à 63 caractères
directement dans le template Helm (`application-app.yaml`) :

    name: {{ printf "%s-%s-%s" $.Values.argocd.project .name (sha1sum .repoURL | trunc 4) | trunc 63 | trimSuffix "-" }}

Le `metadata.name` étant l'identité immuable d'un objet Kubernetes, tronquer
le nom modifie l'identité des applications dont le nom dépasse 63 caractères :
ArgoCD ne peut pas renommer en place, il supprime l'ancienne application et en
recrée une nouvelle.

## Quel est le nouveau comportement ?
On revient à l'ancienne génération du nom (sans troncature dans le chart) :

    name: {{ $.Values.argocd.project }}-{{ .name }}-{{ sha1sum .repoURL | trunc 4 }}

La troncature du nom sera gérée côté code de la console (à 63 caractères pour
rester compatible avec les valeurs de label ArgoCD), au moment de la
génération du nom, afin qu'il reste stable dans le temps.

## Cette PR introduit-elle un breaking change ?
Non — au contraire, elle évite un renommage en masse. La troncature dans le
template aurait recréé les applications dont le nom généré dépasse 63
caractères (approximativement lorsque `len(project) + len(name) > 57`). Les
applications sous cette limite ne sont pas impactées.

## Autres informations
Seule la troncature du nom est annulée. La fonctionnalité d'autosync par
application introduite dans la #232 est conservée.

### Pourquoi 63 caractères ?
Il existe deux règles de nommage dans Kubernetes :
- **Label DNS (RFC 1123 label)** — max **63** caractères (ex : noms de Service,
  valeurs de label).
- **Sous-domaine DNS (RFC 1123 subdomain)** — max **253** caractères (valeur par
  défaut pour la plupart des noms d'objets, y compris les objets de CRD).

Une `Application` ArgoCD est une CRD (`argoproj.io/v1alpha1`) : son
`metadata.name` suit la règle du **sous-domaine DNS**, donc l'API accepte
jusqu'à **253** caractères. Le plafond de 63 ne vient donc pas d'une limite de
nom d'objet Kubernetes, mais du fait qu'ArgoCD utilise le nom de l'application
comme **valeur de label** (`argocd.argoproj.io/instance` /
`app.kubernetes.io/instance` pour le tracking), et que les **valeurs de label**
sont plafonnées à **63** caractères. C'est pourquoi la troncature côté console
doit viser 63 caractères.
