### PR TITLE
fix(dso-backup): fiabiliser le scale-down des workloads pendant le backup

### DIFF
--- a/charts/dso-backup/Chart.yaml
+++ b/charts/dso-backup/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   - Resources only: Backup Kubernetes resources without database
   - CNPG integrated: Orchestrate application shutdown + CNPG backup + Velero
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.0.0"
 keywords:
   - velero

--- a/charts/dso-backup/README.md
+++ b/charts/dso-backup/README.md
@@ -1,6 +1,6 @@
 # dso-backup
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for orchestrating Velero backups with different strategies:
 - Resources only: Backup Kubernetes resources without database
@@ -30,7 +30,8 @@ Generic Helm chart for orchestrating Velero backups with different strategies:
 | rbac.create | bool | `true` |  |
 | rbac.serviceAccountAnnotations | object | `{}` |  |
 | rbac.serviceAccountName | string | `""` |  |
-| schedule.backoffLimit | int | `0` |  |
+| schedule.activeDeadlineSeconds | int | `3600` |  |
+| schedule.backoffLimit | int | `2` |  |
 | schedule.cron | string | `"0 2 * * *"` |  |
 | schedule.failedJobsHistoryLimit | int | `3` |  |
 | schedule.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/dso-backup/templates/configmap-app-scaler.yaml
+++ b/charts/dso-backup/templates/configmap-app-scaler.yaml
@@ -27,17 +27,21 @@ data:
     echo "Scaling down {{ $workload.type }}/{{ $workload.name }} to 0 replicas..."
     kubectl scale {{ $workload.type }} {{ $workload.name }} -n ${NAMESPACE} --replicas=0
 
+    # Poll the workload's own .status.replicas
     echo "Waiting for pods to terminate (timeout: {{ $workload.shutdownTimeout }}s)..."
-    {{- if $workload.podLabelSelector }}
-    kubectl wait --for=delete pod \
-      {{- range $key, $value := $workload.podLabelSelector }}
-      -l {{ $key }}={{ $value }} \
-      {{- end }}
-      -n ${NAMESPACE} \
-      --timeout={{ $workload.shutdownTimeout }}s || true
-    {{- else }}
-    sleep 30
-    {{- end }}
+    _deadline=$((SECONDS + {{ $workload.shutdownTimeout }}))
+    while true; do
+      _current=$(kubectl get {{ $workload.type }} {{ $workload.name }} -n ${NAMESPACE} \
+        -o jsonpath='{.status.replicas}' --request-timeout=30s 2>/dev/null || echo "")
+      if [ -z "${_current}" ] || [ "${_current}" = "0" ]; then
+        break
+      fi
+      if [ ${SECONDS} -ge ${_deadline} ]; then
+        echo "⚠️  Timeout - {{ $workload.type }}/{{ $workload.name }} still reports ${_current} replica(s)"
+        break
+      fi
+      sleep 5
+    done
 
     echo "✓ {{ $workload.type }}/{{ $workload.name }} scaled down"
     echo ""
@@ -66,17 +70,10 @@ data:
     echo "Scaling {{ $workload.type }}/{{ $workload.name }} back to {{ $workload.replicas }} replicas..."
     kubectl scale {{ $workload.type }} {{ $workload.name }} -n ${NAMESPACE} --replicas={{ $workload.replicas }}
 
+    # Wait on the workload's own rollout (single object)
     echo "Waiting for pods to be ready..."
-    {{- if $workload.podLabelSelector }}
-    kubectl wait --for=condition=ready pod \
-      {{- range $key, $value := $workload.podLabelSelector }}
-      -l {{ $key }}={{ $value }} \
-      {{- end }}
-      -n ${NAMESPACE} \
+    kubectl rollout status {{ $workload.type }}/{{ $workload.name }} -n ${NAMESPACE} \
       --timeout=300s || echo "⚠️  Timeout - check pods manually"
-    {{- else }}
-    sleep 30
-    {{- end }}
 
     echo "✓ {{ $workload.type }}/{{ $workload.name }} scaled to {{ $workload.replicas }} replicas"
     echo ""

--- a/charts/dso-backup/templates/cronjob-backup.yaml
+++ b/charts/dso-backup/templates/cronjob-backup.yaml
@@ -27,6 +27,9 @@ spec:
         spec:
           serviceAccountName: {{ include "dso-backup.serviceAccountName" . }}
           restartPolicy: Never
+          {{- with .Values.schedule.activeDeadlineSeconds }}
+          activeDeadlineSeconds: {{ . }}
+          {{- end }}
           containers:
           - name: backup-orchestrator
             image: "{{ include "dso-backup.image" . }}"

--- a/charts/dso-backup/values.yaml
+++ b/charts/dso-backup/values.yaml
@@ -30,7 +30,10 @@ schedule:
   failedJobsHistoryLimit: 3
 
   # Number of retries before marking job as failed
-  backoffLimit: 0
+  backoffLimit: 2
+
+  # Hard wall-clock limit (seconds) for a single backup pod.
+  activeDeadlineSeconds: 3600  # 1 hour
 
   # TTL for completed jobs (seconds)
   ttlSecondsAfterFinished: 3600  # 1 hour


### PR DESCRIPTION
… on shared pod labels

## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

Le scale-down des workloads pouvait bloquer indéfiniment et empêcher le backup de se lancer (workloads laissés à 0). On remplace le kubectl wait sur label selector par un suivi du statut du workload lui-même, et on ajoute un retry + un délai max sur le CronJob.

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les scripts scale-down.sh / scale-up.sh attendent les pods via kubectl wait --for=... pod -l <podLabelSelector>. Comme les composants d'une même
  stack partagent des labels (app.kubernetes.io/instance, release…), le wait matche des pods d'autres composants qui ne sont jamais scalés à 0
  (harbor-exporter, gitlab-gitaly-0). Chaque wait bloque alors pendant tout le shutdownTimeout puis échoue en context deadline exceeded /
  throttling client. Résultat : le scale-down traîne ~20 min, le pre-hook CNPG et le backup Velero ne démarrent jamais, et les workloads restent
  scalés à 0.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
- scale-down : polling sur le .status.replicas du workload ciblé (avec --request-timeout), plus aucun match sur les pods voisins → chaque
  workload se termine en quelques secondes.
- scale-up : kubectl rollout status <type>/<name> (un seul objet, race-free, sans throttling).
- CronJob : backoffLimit 0 → 2 (une panne transitoire se répare toute seule) et ajout d'un activeDeadlineSeconds (3600s, niveau pod) pour qu'un
  pod bloqué ne gèle pas tous les backups suivants (concurrencyPolicy: Forbid).
- Chart bumpé 1.0.3 → 1.0.4.


## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
