### PR TITLE
fix: :bug: always scale workloads back up and propagate backup failures

### DIFF
--- a/charts/dso-backup/Chart.yaml
+++ b/charts/dso-backup/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   - Resources only: Backup Kubernetes resources without database
   - CNPG integrated: Orchestrate application shutdown + CNPG backup + Velero
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.0.0"
 keywords:
   - velero

--- a/charts/dso-backup/README.md
+++ b/charts/dso-backup/README.md
@@ -1,6 +1,6 @@
 # dso-backup
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for orchestrating Velero backups with different strategies:
 - Resources only: Backup Kubernetes resources without database
@@ -30,15 +30,15 @@ Generic Helm chart for orchestrating Velero backups with different strategies:
 | rbac.create | bool | `true` |  |
 | rbac.serviceAccountAnnotations | object | `{}` |  |
 | rbac.serviceAccountName | string | `""` |  |
-| schedule.activeDeadlineSeconds | int | `3600` |  |
+| schedule.activeDeadlineSeconds | int | `7200` |  |
 | schedule.backoffLimit | int | `2` |  |
-| schedule.cron | string | `"0 2 * * *"` |  |
+| schedule.cron | string | `"0 0 * * *"` |  |
 | schedule.failedJobsHistoryLimit | int | `3` |  |
 | schedule.image.pullPolicy | string | `"IfNotPresent"` |  |
 | schedule.image.repository | string | `"ghcr.io/cloud-pi-native/backup-tools"` |  |
 | schedule.image.tag | string | `""` |  |
 | schedule.successfulJobsHistoryLimit | int | `3` |  |
-| schedule.ttlSecondsAfterFinished | int | `3600` |  |
+| schedule.ttlSecondsAfterFinished | int | `7200` |  |
 | strategy | string | `"resources-only"` |  |
 | vault.podLabelSelector."app.kubernetes.io/name" | string | `"vault"` |  |
 | vault.s3.bucket | string | `""` |  |

--- a/charts/dso-backup/templates/configmap-app-scaler.yaml
+++ b/charts/dso-backup/templates/configmap-app-scaler.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   scale-down.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  SCALE DOWN APPLICATION"
@@ -55,7 +55,7 @@ data:
 
   scale-up.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  SCALE UP APPLICATION"

--- a/charts/dso-backup/templates/configmap-cnpg-hooks.yaml
+++ b/charts/dso-backup/templates/configmap-cnpg-hooks.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   cnpg-pre-hook.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  CNPG PRE-HOOK"
@@ -88,7 +88,7 @@ data:
       fi
 
       echo "  Backup status: $STATUS (attempt $i/60)"
-      sleep 10
+      sleep 30
     done
 
     if [ "$STATUS" != "completed" ]; then
@@ -123,7 +123,7 @@ data:
 
   cnpg-post-hook.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  CNPG POST-HOOK"
@@ -159,7 +159,7 @@ data:
     #   1. Velero restore completed
     #   2. Cluster CR exists with cnpg.io/reconciliationLoop=disabled annotation
 
-    set -e
+    set -Eeo pipefail
 
     NAMESPACE="{{ include "dso-backup.namespace" . }}"
     CLUSTER_NAME="{{ include "dso-backup.cnpgClusterName" . }}"

--- a/charts/dso-backup/templates/configmap-vault-hooks.yaml
+++ b/charts/dso-backup/templates/configmap-vault-hooks.yaml
@@ -23,7 +23,7 @@ metadata:
 data:
   vault-pre-hook.sh: |
     #!/bin/bash
-    set -euo pipefail
+    set -Eeuo pipefail
 
     echo "=========================================="
     echo "  VAULT PRE-HOOK (raft snapshot -> S3)"

--- a/charts/dso-backup/templates/configmap-velero-backup.yaml
+++ b/charts/dso-backup/templates/configmap-velero-backup.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   velero-backup.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  CREATE VELERO BACKUP"

--- a/charts/dso-backup/templates/cronjob-scripts.yaml
+++ b/charts/dso-backup/templates/cronjob-scripts.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   orchestrator.sh: |
     #!/bin/bash
-    set -e
+    set -Eeo pipefail
 
     echo "=========================================="
     echo "  Backup Orchestrator - {{ .Values.global.appName }}"
@@ -35,35 +35,62 @@ data:
     fi
     export VELERO_BACKUP_NAME="${BACKUP_NAME}"
 
-    # Error handler
-    cleanup_on_error() {
-      echo ""
-      echo "=========================================="
-      echo "  ❌ ERROR OCCURRED - Running cleanup"
-      echo "=========================================="
+    # Single "finally" handler, run on EVERY exit path via the EXIT trap
+    # (success, explicit exit, or set -e abort - e.g. a hook timing out).
+    #   - on failure only: run the CNPG cleanup post-hook
+    #   - in ALL cases: scale the application back up
+    #   - re-exit with the original code so a failed backup stays failed
+    on_exit() {
+      rc=$?
 
-      {{- if eq .Values.strategy "cnpg" }}
-      # Run CNPG post-hook for cleanup
-      if [ -f /scripts/strategy/cnpg-post-hook.sh ]; then
-        echo "Running CNPG cleanup..."
-        bash /scripts/strategy/cnpg-post-hook.sh || true
+      if [ "${rc}" -ne 0 ]; then
+        echo ""
+        echo "=========================================="
+        echo "  ❌ ERROR OCCURRED (exit code ${rc}) - Running cleanup"
+        echo "=========================================="
+        {{- if eq .Values.strategy "cnpg" }}
+        if [ -f /scripts/strategy/cnpg-post-hook.sh ]; then
+          echo "Running CNPG cleanup..."
+          bash /scripts/strategy/cnpg-post-hook.sh || true
+        fi
+        {{- end }}
       fi
-      {{- end }}
 
       {{- if and (ne .Values.strategy "vault") .Values.application.workloads }}
-      # Scale application back up
+      # Always scale the application back up (idempotent).
       if [ -f /scripts/app/scale-up.sh ]; then
+        echo ""
         echo "Scaling application back up..."
-        bash /scripts/app/scale-up.sh || true
+        bash /scripts/app/scale-up.sh || echo "⚠️  WARNING: scale-up failed - check application replicas manually"
       fi
       {{- end }}
 
-      echo ""
-      echo "Cleanup completed - check logs above for error details"
-      exit 1
+      if [ "${rc}" -eq 0 ]; then
+        echo ""
+        echo "=========================================="
+        echo "  ✅ BACKUP ORCHESTRATION COMPLETED"
+        echo "=========================================="
+        echo ""
+        echo "Summary:"
+        echo "  - Strategy: {{ .Values.strategy }}"
+        echo "  - Velero Backup: ${VELERO_BACKUP_NAME}"
+        echo "  - Storage Location: ${STORAGE_LOCATION}"
+        echo "  - TTL: ${TTL}"
+        {{- if .Values.application.workloads }}
+        echo "  - Workloads:"
+        {{- range .Values.application.workloads }}
+        echo "    - {{ .type }}/{{ .name }} ({{ .replicas }} replicas)"
+        {{- end }}
+        {{- end }}
+        echo ""
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - Backup completed successfully!"
+        echo ""
+      fi
+
+      exit "${rc}"
     }
 
-    trap cleanup_on_error ERR
+    trap on_exit EXIT
 
     # =========================================
     # STEP 1: SCALE DOWN APPLICATION
@@ -128,39 +155,8 @@ data:
     {{- end }}
 
     # =========================================
-    # STEP 5: SCALE UP APPLICATION
+    # STEP 5: SCALE UP APPLICATION + FINAL SUMMARY
     # =========================================
-    {{- if and (ne .Values.strategy "vault") .Values.application.workloads }}
-    echo "=========================================="
-    echo "  STEP 5: SCALE UP APPLICATION"
-    echo "=========================================="
-    echo ""
-
-    bash /scripts/app/scale-up.sh
-    {{- else }}
-    echo "Step 5: scale-up skipped (strategy={{ .Values.strategy }})"
-    echo ""
-    {{- end }}
-
-    # =========================================
-    # FINAL SUMMARY
-    # =========================================
-    echo ""
-    echo "=========================================="
-    echo "  ✅ BACKUP ORCHESTRATION COMPLETED"
-    echo "=========================================="
-    echo ""
-    echo "Summary:"
-    echo "  - Strategy: {{ .Values.strategy }}"
-    echo "  - Velero Backup: ${VELERO_BACKUP_NAME}"
-    echo "  - Storage Location: ${STORAGE_LOCATION}"
-    echo "  - TTL: ${TTL}"
-    {{- if .Values.application.workloads }}
-    echo "  - Workloads:"
-    {{- range .Values.application.workloads }}
-    echo "    - {{ .type }}/{{ .name }} ({{ .replicas }} replicas)"
-    {{- end }}
-    {{- end }}
-    echo ""
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - Backup completed successfully!"
-    echo ""
+    # Both handled by the on_exit trap: the application is always scaled back up
+    # (success or failure, e.g. a hook timeout), and the success summary is
+    # printed afterwards only when the backup completed with exit code 0.

--- a/charts/dso-backup/templates/rbac.yaml
+++ b/charts/dso-backup/templates/rbac.yaml
@@ -26,7 +26,7 @@ rules:
 # Permissions for scaling workloads (get needed to check current state)
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets", "replicasets"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["deployments/scale", "statefulsets/scale", "replicasets/scale"]
   verbs: ["get", "patch"]

--- a/charts/dso-backup/values.yaml
+++ b/charts/dso-backup/values.yaml
@@ -20,8 +20,8 @@ strategy: "resources-only"
 
 # Schedule configuration for CronJob
 schedule:
-  # Cron schedule (default: daily at 2 AM)
-  cron: "0 2 * * *"
+  # Cron schedule
+  cron: "0 0 * * *"
 
   # Number of successful jobs to keep in history
   successfulJobsHistoryLimit: 3
@@ -33,10 +33,10 @@ schedule:
   backoffLimit: 2
 
   # Hard wall-clock limit (seconds) for a single backup pod.
-  activeDeadlineSeconds: 3600  # 1 hour
+  activeDeadlineSeconds: 7200  # 2 hour
 
   # TTL for completed jobs (seconds)
-  ttlSecondsAfterFinished: 3600  # 1 hour
+  ttlSecondsAfterFinished: 7200  # 2 hour
 
   # Container image for the backup CronJob.
   # Bundles kubectl + mc (used by all strategies, including vault).


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->
Cette PR fiabilise l'orchestration du backup (dso-backup), en particulier la remontée des workloads (scale-up) et la propagation des erreurs. Le déclencheur : lors d'un timeout dans un hook, l'application pouvait rester scale-down (0 replica) car le scale-up n'était pas garanti, et certains échecs passaient inaperçus.

  Principaux changements :
  - Refactor de orchestrator.sh : un unique trap ... EXIT (on_exit) remplace le trap ... ERR.
  - Durcissement de tous les scripts avec set -Eeo pipefail (+ -E pour vault-pre-hook).
  - Ajustements de config : intervalle de polling CNPG (sleep 10 → 30), activeDeadlineSeconds et ttlSecondsAfterFinished (1h → 2h), cron → minuit,
  RBAC list/watch pour le polling de statut.

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
  - Le scale-up des workloads reposait sur trap cleanup_on_error ERR + une étape STEP 5 dédiée. Le trap ERR ne se déclenche pas dans plusieurs cas
  (échec dans une fonction sans -E, échec dans un pipeline sans pipefail), et un timeout de hook pouvait laisser l'application scale-down (0 
  replica).
  - Sans pipefail, un échec au milieu d'un pipeline était silencieusement masqué (le sous-script sortait en 0), donc l'orchestrateur croyait le
  backup réussi.
  - La logique de scale-up était dupliquée (dans cleanup_on_error et dans STEP 5).
## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
  - Un seul handler on_exit branché sur trap ... EXIT s'exécute sur tous les chemins de sortie (succès, exit, abort set -e, timeout de hook) :
    - en cas d'échec uniquement : lance le cleanup CNPG (post-hook) ;
    - dans tous les cas : scale up les workloads (idempotent) ;
    - en cas de succès uniquement : affiche le résumé final ;
    - toujours : ressort avec le code d'origine → un backup raté garde le Job en failed.
  - Avec set -Eeo pipefail, un échec (ex. timeout) fait bien échouer le script, et le trap remonte quand même l'application.
  - Plus de scale-up dupliqué : la remontée est centralisée dans on_exit.
  - Le scale-up reste gardé par la même condition que le scale-down (strategy != vault et workloads définis) : on ne remonte que ce qui a été
  descendu.
## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
